### PR TITLE
eliminate context func allocations

### DIFF
--- a/broker/context.go
+++ b/broker/context.go
@@ -6,12 +6,14 @@ import (
 
 type brokerKey struct{}
 
+var brokerKeyVal = brokerKey{}
+
 // FromContext returns broker from passed context
 func FromContext(ctx context.Context) (Broker, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(brokerKey{}).(Broker)
+	c, ok := ctx.Value(brokerKeyVal).(Broker)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, s Broker) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, brokerKey{}, s)
+	return context.WithValue(ctx, brokerKeyVal, s)
 }
 
 // SetSubscribeOption returns a function to setup a context with given value

--- a/client/context.go
+++ b/client/context.go
@@ -6,12 +6,14 @@ import (
 
 type clientKey struct{}
 
+var clientKeyVal = clientKey{}
+
 // FromContext get client from context
 func FromContext(ctx context.Context) (Client, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(clientKey{}).(Client)
+	c, ok := ctx.Value(clientKeyVal).(Client)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Client) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, clientKey{}, c)
+	return context.WithValue(ctx, clientKeyVal, c)
 }
 
 // SetCallOption returns a function to setup a context with given value

--- a/client/context_test.go
+++ b/client/context_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFromContext(t *testing.T) {
-	ctx := context.WithValue(context.TODO(), clientKey{}, NewClient())
+	ctx := context.WithValue(context.TODO(), clientKeyVal, NewClient())
 
 	c, ok := FromContext(ctx)
 	if c == nil || !ok {

--- a/client/lookup.go
+++ b/client/lookup.go
@@ -11,6 +11,12 @@ import (
 // LookupFunc is used to lookup routes for a service
 type LookupFunc func(context.Context, Request, CallOptions) ([]string, error)
 
+type routesByMetric []router.Route
+
+func (r routesByMetric) Len() int           { return len(r) }
+func (r routesByMetric) Less(i, j int) bool { return r[i].Metric < r[j].Metric }
+func (r routesByMetric) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+
 // LookupRoute for a request using the router and then choose one using the selector
 func LookupRoute(_ context.Context, req Request, opts CallOptions) ([]string, error) {
 	// check to see if an address was provided as a call option
@@ -40,9 +46,7 @@ func LookupRoute(_ context.Context, req Request, opts CallOptions) ([]string, er
 	}
 
 	// sort by lowest metric first
-	sort.Slice(routes, func(i, j int) bool {
-		return routes[i].Metric < routes[j].Metric
-	})
+	sort.Sort(routesByMetric(routes))
 
 	addrs := make([]string, 0, len(routes))
 	for _, route := range routes {

--- a/client/noop.go
+++ b/client/noop.go
@@ -15,6 +15,8 @@ import (
 	"go.unistack.org/micro/v4/tracer"
 )
 
+const statusSuccess = "200"
+
 type noopClient struct {
 	funcCall   FuncCall
 	funcStream FuncStream
@@ -170,25 +172,26 @@ func (n *noopClient) String() string {
 }
 
 func (n *noopClient) Call(ctx context.Context, req Request, rsp interface{}, opts ...CallOption) error {
+	endpoint := req.Endpoint()
 	ts := time.Now()
-	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", req.Endpoint()).Inc()
+	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", endpoint).Inc()
 	var sp tracer.Span
 	ctx, sp = n.opts.Tracer.Start(ctx, "rpc-client",
 		tracer.WithSpanKind(tracer.SpanKindClient),
-		tracer.WithSpanLabels("endpoint", req.Endpoint()),
+		tracer.WithSpanLabels("endpoint", endpoint),
 	)
 	err := n.funcCall(ctx, req, rsp, opts...)
-	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", req.Endpoint()).Dec()
+	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", endpoint).Dec()
 	te := time.Since(ts)
-	n.opts.Meter.Summary(semconv.ClientRequestLatencyMicroseconds, "endpoint", req.Endpoint()).Update(te.Seconds())
-	n.opts.Meter.Histogram(semconv.ClientRequestDurationSeconds, "endpoint", req.Endpoint()).Update(te.Seconds())
+	n.opts.Meter.Summary(semconv.ClientRequestLatencyMicroseconds, "endpoint", endpoint).Update(te.Seconds())
+	n.opts.Meter.Histogram(semconv.ClientRequestDurationSeconds, "endpoint", endpoint).Update(te.Seconds())
 
 	if me := errors.FromError(err); me == nil {
 		sp.Finish()
-		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", req.Endpoint(), "status", "success", "code", strconv.Itoa(int(200))).Inc()
+		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", endpoint, "status", "success", "code", statusSuccess).Inc()
 	} else {
 		sp.SetStatus(tracer.SpanStatusError, err.Error())
-		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", req.Endpoint(), "status", "failure", "code", strconv.Itoa(int(me.Code))).Inc()
+		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", endpoint, "status", "failure", "code", strconv.Itoa(int(me.Code))).Inc()
 	}
 
 	return err
@@ -290,34 +293,25 @@ func (n *noopClient) fnCall(ctx context.Context, req Request, rsp interface{}, o
 		return err
 	}
 
-	ch := make(chan error, callOpts.Retries)
 	var gerr error
 
 	for i := 0; i <= callOpts.Retries; i++ {
-		go func() {
-			ch <- call(i)
-		}()
-
-		select {
-		case <-ctx.Done():
-			return errors.New("go.micro.client", fmt.Sprintf("%v", ctx.Err()), 408)
-		case err := <-ch:
-			// if the call succeeded lets bail early
-			if err == nil {
-				return nil
-			}
-
-			retry, rerr := callOpts.Retry(ctx, req, i, err)
-			if rerr != nil {
-				return rerr
-			}
-
-			if !retry {
-				return err
-			}
-
-			gerr = err
+		err := call(i)
+		// if the call succeeded lets bail early
+		if err == nil {
+			return nil
 		}
+
+		retry, rerr := callOpts.Retry(ctx, req, i, err)
+		if rerr != nil {
+			return rerr
+		}
+
+		if !retry {
+			return err
+		}
+
+		gerr = err
 	}
 
 	return gerr
@@ -328,25 +322,26 @@ func (n *noopClient) NewRequest(service, endpoint string, _ interface{}, _ ...Re
 }
 
 func (n *noopClient) Stream(ctx context.Context, req Request, opts ...CallOption) (Stream, error) {
+	endpoint := req.Endpoint()
 	ts := time.Now()
-	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", req.Endpoint()).Inc()
+	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", endpoint).Inc()
 	var sp tracer.Span
 	ctx, sp = n.opts.Tracer.Start(ctx, "rpc-client",
 		tracer.WithSpanKind(tracer.SpanKindClient),
-		tracer.WithSpanLabels("endpoint", req.Endpoint()),
+		tracer.WithSpanLabels("endpoint", endpoint),
 	)
 	stream, err := n.funcStream(ctx, req, opts...)
-	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", req.Endpoint()).Dec()
+	n.opts.Meter.Counter(semconv.ClientRequestInflight, "endpoint", endpoint).Dec()
 	te := time.Since(ts)
-	n.opts.Meter.Summary(semconv.ClientRequestLatencyMicroseconds, "endpoint", req.Endpoint()).Update(te.Seconds())
-	n.opts.Meter.Histogram(semconv.ClientRequestDurationSeconds, "endpoint", req.Endpoint()).Update(te.Seconds())
+	n.opts.Meter.Summary(semconv.ClientRequestLatencyMicroseconds, "endpoint", endpoint).Update(te.Seconds())
+	n.opts.Meter.Histogram(semconv.ClientRequestDurationSeconds, "endpoint", endpoint).Update(te.Seconds())
 
 	if me := errors.FromError(err); me == nil {
 		sp.Finish()
-		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", req.Endpoint(), "status", "success", "code", strconv.Itoa(int(200))).Inc()
+		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", endpoint, "status", "success", "code", statusSuccess).Inc()
 	} else {
 		sp.SetStatus(tracer.SpanStatusError, err.Error())
-		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", req.Endpoint(), "status", "failure", "code", strconv.Itoa(int(me.Code))).Inc()
+		n.opts.Meter.Counter(semconv.ClientRequestTotal, "endpoint", endpoint, "status", "failure", "code", strconv.Itoa(int(me.Code))).Inc()
 	}
 
 	return stream, err
@@ -453,40 +448,25 @@ func (n *noopClient) fnStream(ctx context.Context, req Request, opts ...CallOpti
 		return stream, cerr
 	}
 
-	type response struct {
-		stream Stream
-		err    error
-	}
-
-	ch := make(chan response, callOpts.Retries)
 	var grr error
 
 	for i := 0; i <= callOpts.Retries; i++ {
-		go func() {
-			s, cerr := call(i)
-			ch <- response{s, cerr}
-		}()
-
-		select {
-		case <-ctx.Done():
-			return nil, errors.New("go.micro.client", fmt.Sprintf("%v", ctx.Err()), 408)
-		case rsp := <-ch:
-			// if the call succeeded lets bail early
-			if rsp.err == nil {
-				return rsp.stream, nil
-			}
-
-			retry, rerr := callOpts.Retry(ctx, req, i, err)
-			if rerr != nil {
-				return nil, rerr
-			}
-
-			if !retry {
-				return nil, rsp.err
-			}
-
-			grr = rsp.err
+		s, cerr := call(i)
+		// if the call succeeded lets bail early
+		if cerr == nil {
+			return s, nil
 		}
+
+		retry, rerr := callOpts.Retry(ctx, req, i, cerr)
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		if !retry {
+			return nil, cerr
+		}
+
+		grr = cerr
 	}
 
 	return nil, grr

--- a/codec/context.go
+++ b/codec/context.go
@@ -6,12 +6,14 @@ import (
 
 type codecKey struct{}
 
+var codecKeyVal = codecKey{}
+
 // FromContext returns codec from context
 func FromContext(ctx context.Context) (Codec, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(codecKey{}).(Codec)
+	c, ok := ctx.Value(codecKeyVal).(Codec)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Codec) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, codecKey{}, c)
+	return context.WithValue(ctx, codecKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/config/context.go
+++ b/config/context.go
@@ -6,12 +6,14 @@ import (
 
 type configKey struct{}
 
+var configKeyVal = configKey{}
+
 // FromContext returns store from context
 func FromContext(ctx context.Context) (Config, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(configKey{}).(Config)
+	c, ok := ctx.Value(configKeyVal).(Config)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Config) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, configKey{}, c)
+	return context.WithValue(ctx, configKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/context.go
+++ b/context.go
@@ -4,12 +4,14 @@ import "context"
 
 type serviceKey struct{}
 
+var serviceKeyVal = serviceKey{}
+
 // FromContext retrieves a Service from the Context.
 func FromContext(ctx context.Context) (Service, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	s, ok := ctx.Value(serviceKey{}).(Service)
+	s, ok := ctx.Value(serviceKeyVal).(Service)
 	return s, ok
 }
 
@@ -18,5 +20,5 @@ func NewContext(ctx context.Context, s Service) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, serviceKey{}, s)
+	return context.WithValue(ctx, serviceKeyVal, s)
 }

--- a/flow/context.go
+++ b/flow/context.go
@@ -6,12 +6,14 @@ import (
 
 type flowKey struct{}
 
+var flowKeyVal = flowKey{}
+
 // FromContext returns Flow from context
 func FromContext(ctx context.Context) (Flow, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(flowKey{}).(Flow)
+	c, ok := ctx.Value(flowKeyVal).(Flow)
 	return c, ok
 }
 
@@ -20,7 +22,7 @@ func NewContext(ctx context.Context, f Flow) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, flowKey{}, f)
+	return context.WithValue(ctx, flowKeyVal, f)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/logger/context.go
+++ b/logger/context.go
@@ -4,12 +4,14 @@ import "context"
 
 type loggerKey struct{}
 
+var loggerKeyVal = loggerKey{}
+
 // FromContext returns logger from passed context
 func FromContext(ctx context.Context) (Logger, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	l, ok := ctx.Value(loggerKey{}).(Logger)
+	l, ok := ctx.Value(loggerKeyVal).(Logger)
 	return l, ok
 }
 
@@ -27,7 +29,7 @@ func NewContext(ctx context.Context, l Logger) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, loggerKey{}, l)
+	return context.WithValue(ctx, loggerKeyVal, l)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/metadata/context.go
+++ b/metadata/context.go
@@ -58,22 +58,28 @@ type (
 	}
 )
 
+var (
+	metadataCurrentKeyVal  = metadataCurrentKey{}
+	metadataIncomingKeyVal = metadataIncomingKey{}
+	metadataOutgoingKeyVal = metadataOutgoingKey{}
+)
+
 // NewContext creates a new context with the provided Metadata attached.
 // The Metadata must not be modified after calling this function.
 func NewContext(ctx context.Context, md Metadata) context.Context {
-	return context.WithValue(ctx, metadataCurrentKey{}, rawMetadata{md: md})
+	return context.WithValue(ctx, metadataCurrentKeyVal, rawMetadata{md: md})
 }
 
 // NewIncomingContext creates a new context with the provided incoming Metadata attached.
 // The Metadata must not be modified after calling this function.
 func NewIncomingContext(ctx context.Context, md Metadata) context.Context {
-	return context.WithValue(ctx, metadataIncomingKey{}, rawMetadata{md: md})
+	return context.WithValue(ctx, metadataIncomingKeyVal, rawMetadata{md: md})
 }
 
 // NewOutgoingContext creates a new context with the provided outgoing Metadata attached.
 // The Metadata must not be modified after calling this function.
 func NewOutgoingContext(ctx context.Context, md Metadata) context.Context {
-	return context.WithValue(ctx, metadataOutgoingKey{}, rawMetadata{md: md})
+	return context.WithValue(ctx, metadataOutgoingKeyVal, rawMetadata{md: md})
 }
 
 // AppendContext returns a new context with the provided key-value pairs (kv)
@@ -83,7 +89,7 @@ func AppendContext(ctx context.Context, kv ...string) context.Context {
 	if len(kv)%2 == 1 {
 		panic(fmt.Sprintf("metadata: AppendContext got an odd number of input pairs for metadata: %d", len(kv)))
 	}
-	md, _ := ctx.Value(metadataCurrentKey{}).(rawMetadata)
+	md, _ := ctx.Value(metadataCurrentKeyVal).(rawMetadata)
 	added := make([][]string, len(md.added)+1)
 	copy(added, md.added)
 	kvCopy := make([]string, 0, len(kv))
@@ -91,7 +97,7 @@ func AppendContext(ctx context.Context, kv ...string) context.Context {
 		kvCopy = append(kvCopy, strings.ToLower(kv[i]), kv[i+1])
 	}
 	added[len(added)-1] = kvCopy
-	return context.WithValue(ctx, metadataCurrentKey{}, rawMetadata{md: md.md, added: added})
+	return context.WithValue(ctx, metadataCurrentKeyVal, rawMetadata{md: md.md, added: added})
 }
 
 // AppendOutgoingContext returns a new context with the provided key-value pairs (kv)
@@ -101,7 +107,7 @@ func AppendOutgoingContext(ctx context.Context, kv ...string) context.Context {
 	if len(kv)%2 == 1 {
 		panic(fmt.Sprintf("metadata: AppendOutgoingContext got an odd number of input pairs for metadata: %d", len(kv)))
 	}
-	md, _ := ctx.Value(metadataOutgoingKey{}).(rawMetadata)
+	md, _ := ctx.Value(metadataOutgoingKeyVal).(rawMetadata)
 	added := make([][]string, len(md.added)+1)
 	copy(added, md.added)
 	kvCopy := make([]string, 0, len(kv))
@@ -109,13 +115,13 @@ func AppendOutgoingContext(ctx context.Context, kv ...string) context.Context {
 		kvCopy = append(kvCopy, strings.ToLower(kv[i]), kv[i+1])
 	}
 	added[len(added)-1] = kvCopy
-	return context.WithValue(ctx, metadataOutgoingKey{}, rawMetadata{md: md.md, added: added})
+	return context.WithValue(ctx, metadataOutgoingKeyVal, rawMetadata{md: md.md, added: added})
 }
 
 // FromContext retrieves a deep copy of the metadata from the context and returns it
 // with a boolean indicating if it was found.
 func FromContext(ctx context.Context) (Metadata, bool) {
-	raw, ok := ctx.Value(metadataCurrentKey{}).(rawMetadata)
+	raw, ok := ctx.Value(metadataCurrentKeyVal).(rawMetadata)
 	if !ok {
 		return nil, false
 	}
@@ -153,7 +159,7 @@ func MustContext(ctx context.Context) Metadata {
 // FromIncomingContext retrieves a deep copy of the metadata from the context and returns it
 // with a boolean indicating if it was found.
 func FromIncomingContext(ctx context.Context) (Metadata, bool) {
-	raw, ok := ctx.Value(metadataIncomingKey{}).(rawMetadata)
+	raw, ok := ctx.Value(metadataIncomingKeyVal).(rawMetadata)
 	if !ok {
 		return nil, false
 	}
@@ -191,7 +197,7 @@ func MustIncomingContext(ctx context.Context) Metadata {
 // FromOutgoingContext retrieves a deep copy of the metadata from the context and returns it
 // with a boolean indicating if it was found.
 func FromOutgoingContext(ctx context.Context) (Metadata, bool) {
-	raw, ok := ctx.Value(metadataOutgoingKey{}).(rawMetadata)
+	raw, ok := ctx.Value(metadataOutgoingKeyVal).(rawMetadata)
 	if !ok {
 		return nil, false
 	}
@@ -230,7 +236,7 @@ func MustOutgoingContext(ctx context.Context) Metadata {
 // ValueFromCurrentContext retrieves a deep copy of the metadata for the given key
 // from the context, performing a case-insensitive search if needed. Returns nil if not found.
 func ValueFromCurrentContext(ctx context.Context, key string) []string {
-	md, ok := ctx.Value(metadataCurrentKey{}).(rawMetadata)
+	md, ok := ctx.Value(metadataCurrentKeyVal).(rawMetadata)
 	if !ok {
 		return nil
 	}
@@ -252,7 +258,7 @@ func ValueFromCurrentContext(ctx context.Context, key string) []string {
 // ValueFromIncomingContext retrieves a deep copy of the metadata for the given key
 // from the context, performing a case-insensitive search if needed. Returns nil if not found.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
-	raw, ok := ctx.Value(metadataIncomingKey{}).(rawMetadata)
+	raw, ok := ctx.Value(metadataIncomingKeyVal).(rawMetadata)
 	if !ok {
 		return nil
 	}
@@ -274,7 +280,7 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 // ValueFromOutgoingContext retrieves a deep copy of the metadata for the given key
 // from the context, performing a case-insensitive search if needed. Returns nil if not found.
 func ValueFromOutgoingContext(ctx context.Context, key string) []string {
-	md, ok := ctx.Value(metadataOutgoingKey{}).(rawMetadata)
+	md, ok := ctx.Value(metadataOutgoingKeyVal).(rawMetadata)
 	if !ok {
 		return nil
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -197,7 +197,7 @@ func TestMetadataContext(t *testing.T) {
 }
 
 func TestFromContext(t *testing.T) {
-	ctx := context.WithValue(context.TODO(), metadataCurrentKey{}, rawMetadata{md: New(0)})
+	ctx := context.WithValue(context.TODO(), metadataCurrentKeyVal, rawMetadata{md: New(0)})
 
 	c, ok := FromContext(ctx)
 	if c == nil || !ok {
@@ -215,7 +215,7 @@ func TestNewContext(t *testing.T) {
 }
 
 func TestFromIncomingContext(t *testing.T) {
-	ctx := context.WithValue(context.TODO(), metadataIncomingKey{}, rawMetadata{md: New(0)})
+	ctx := context.WithValue(context.TODO(), metadataIncomingKeyVal, rawMetadata{md: New(0)})
 
 	c, ok := FromIncomingContext(ctx)
 	if c == nil || !ok {
@@ -224,7 +224,7 @@ func TestFromIncomingContext(t *testing.T) {
 }
 
 func TestFromOutgoingContext(t *testing.T) {
-	ctx := context.WithValue(context.TODO(), metadataOutgoingKey{}, rawMetadata{md: New(0)})
+	ctx := context.WithValue(context.TODO(), metadataOutgoingKeyVal, rawMetadata{md: New(0)})
 
 	c, ok := FromOutgoingContext(ctx)
 	if c == nil || !ok {

--- a/meter/context.go
+++ b/meter/context.go
@@ -6,12 +6,14 @@ import (
 
 type meterKey struct{}
 
+var meterKeyVal = meterKey{}
+
 // FromContext get meter from context
 func FromContext(ctx context.Context) (Meter, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(meterKey{}).(Meter)
+	c, ok := ctx.Value(meterKeyVal).(Meter)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Meter) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, meterKey{}, c)
+	return context.WithValue(ctx, meterKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/register/context.go
+++ b/register/context.go
@@ -6,12 +6,14 @@ import (
 
 type registerKey struct{}
 
+var registerKeyVal = registerKey{}
+
 // FromContext get register from context
 func FromContext(ctx context.Context) (Register, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(registerKey{}).(Register)
+	c, ok := ctx.Value(registerKeyVal).(Register)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Register) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, registerKey{}, c)
+	return context.WithValue(ctx, registerKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/router/context.go
+++ b/router/context.go
@@ -6,12 +6,14 @@ import (
 
 type routerKey struct{}
 
+var routerKeyVal = routerKey{}
+
 // FromContext get router from context
 func FromContext(ctx context.Context) (Router, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(routerKey{}).(Router)
+	c, ok := ctx.Value(routerKeyVal).(Router)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Router) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, routerKey{}, c)
+	return context.WithValue(ctx, routerKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/server/context.go
+++ b/server/context.go
@@ -6,12 +6,14 @@ import (
 
 type serverKey struct{}
 
+var serverKeyVal = serverKey{}
+
 // FromContext returns Server from context
 func FromContext(ctx context.Context) (Server, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(serverKey{}).(Server)
+	c, ok := ctx.Value(serverKeyVal).(Server)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, s Server) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, serverKey{}, s)
+	return context.WithValue(ctx, serverKeyVal, s)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/store/context.go
+++ b/store/context.go
@@ -6,12 +6,14 @@ import (
 
 type storeKey struct{}
 
+var storeKeyVal = storeKey{}
+
 // FromContext get store from context
 func FromContext(ctx context.Context) (Store, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	c, ok := ctx.Value(storeKey{}).(Store)
+	c, ok := ctx.Value(storeKeyVal).(Store)
 	return c, ok
 }
 
@@ -29,7 +31,7 @@ func NewContext(ctx context.Context, c Store) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, storeKey{}, c)
+	return context.WithValue(ctx, storeKeyVal, c)
 }
 
 // SetOption returns a function to setup a context with given value

--- a/tracer/context.go
+++ b/tracer/context.go
@@ -7,12 +7,14 @@ import (
 
 type tracerKey struct{}
 
+var tracerKeyVal = tracerKey{}
+
 // FromContext returns a tracer from context
 func FromContext(ctx context.Context) (Tracer, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	if tracer, ok := ctx.Value(tracerKey{}).(Tracer); ok {
+	if tracer, ok := ctx.Value(tracerKeyVal).(Tracer); ok {
 		return tracer, true
 	}
 	return nil, false
@@ -32,10 +34,12 @@ func NewContext(ctx context.Context, tracer Tracer) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, tracerKey{}, tracer)
+	return context.WithValue(ctx, tracerKeyVal, tracer)
 }
 
 type spanKey struct{}
+
+var spanKeyVal = spanKey{}
 
 // SpanFromContext returns a span from context
 func SpanMustContext(ctx context.Context) Span {
@@ -51,7 +55,7 @@ func SpanFromContext(ctx context.Context) (Span, bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	if span, ok := ctx.Value(spanKey{}).(Span); ok {
+	if span, ok := ctx.Value(spanKeyVal).(Span); ok {
 		return span, true
 	}
 	return nil, false
@@ -62,7 +66,7 @@ func NewSpanContext(ctx context.Context, span Span) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, spanKey{}, span)
+	return context.WithValue(ctx, spanKeyVal, span)
 }
 
 // SetOption returns a function to setup a context with given value


### PR DESCRIPTION
avoid additional memory allocations for NewContext and FromContext
