### PR TITLE
store: add go.mod to retract standalone module versions

### DIFF
--- a/store/go.mod
+++ b/store/go.mod
@@ -1,0 +1,9 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. The store package has been merged into the main module.
+module go.unistack.org/micro/v4/store
+
+go 1.21
+
+retract (
+	[v0.1.0, v0.27.1] // Merged into go.unistack.org/micro/v4; use that module instead
+	[v1.0.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)


### PR DESCRIPTION
The store package was previously published as a standalone Go module (go.unistack.org/micro/v4/store) and has since been merged into the main go.unistack.org/micro/v4 module. This go.mod retracts all old standalone versions (v0.1.0–v0.27.1 and v1.0.0–v1.18.0) and marks the standalone module as deprecated so pkg.go.dev and the Go toolchain direct users to the correct module.

## Pull Request template
Please, go through these steps before clicking submit on this PR.

1. Give a descriptive title to your PR.
2. Provide a description of your changes.
3. Make sure you have some relevant tests.
4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if applicable).

**PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING**
