### PR TITLE
subpkgs: add go.mod to retract all standalone submodule versions

### DIFF
--- a/broker/go.mod
+++ b/broker/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/broker
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/client
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/codec
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/config
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/errors
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/flow/go.mod
+++ b/flow/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/flow
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/fsm/go.mod
+++ b/fsm/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/fsm
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/hooks/go.mod
+++ b/hooks/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/hooks
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/logger
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/metadata/go.mod
+++ b/metadata/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/metadata
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/meter/go.mod
+++ b/meter/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/meter
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/options/go.mod
+++ b/options/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/options
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/profiler/go.mod
+++ b/profiler/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/profiler
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/register/go.mod
+++ b/register/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/register
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/resolver/go.mod
+++ b/resolver/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/resolver
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/router/go.mod
+++ b/router/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/router
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/selector/go.mod
+++ b/selector/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/selector
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/semconv
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/server
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/sync/go.mod
+++ b/sync/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/sync
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/tracer/go.mod
+++ b/tracer/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/tracer
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)

--- a/util/go.mod
+++ b/util/go.mod
@@ -1,0 +1,8 @@
+// Deprecated: Use go.unistack.org/micro/v4 instead. This package has been merged into the main module.
+module go.unistack.org/micro/v4/util
+
+go 1.21
+
+retract (
+	[v0.1.0, v1.18.0] // Merged into go.unistack.org/micro/v4; use that module instead
+)


### PR DESCRIPTION
All subpackages (broker, client, codec, config, errors, flow, fsm, hooks, logger, metadata, meter, options, profiler, register, resolver, router, selector, semconv, server, sync, tracer, util) were previously indexed by proxy.golang.org as standalone modules at versions v0.x/v1.x. They have since been merged into go.unistack.org/micro/v4. These go.mod files retract all old standalone versions and mark each submodule as deprecated.

## Pull Request template
Please, go through these steps before clicking submit on this PR.

1. Give a descriptive title to your PR.
2. Provide a description of your changes.
3. Make sure you have some relevant tests.
4. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if applicable).

**PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING**
