### PR TITLE
feat(logger): level-aware stacktrace via AddStacktrace(Level)

### DIFF
--- a/flow/default.go
+++ b/flow/default.go
@@ -12,7 +12,7 @@ import (
 	ants "github.com/panjf2000/ants/v2"
 	"github.com/heimdalr/dag"
 	"go.unistack.org/micro/v5/client"
-	"go.unistack.org/micro/v5/codec"
+	codecpb "go.unistack.org/micro-proto/v5/codec"
 	"go.unistack.org/micro/v5/metadata"
 	"go.unistack.org/micro/v5/store"
 	"go.unistack.org/micro/v5/util/id"
@@ -108,7 +108,7 @@ func (w *microWorkflow) Abort(ctx context.Context, id string) error {
 
 	// Обновляем статус в хранилище - это прервет выполнение в любом сервисе
 	// так как handleWorkflow проверяет статус перед каждым шагом
-	if err := workflowStore.Write(ctx, "status", &codec.Frame{Data: []byte(StatusAborted.String())}); err != nil {
+	if err := workflowStore.Write(ctx, "status", &codecpb.Frame{Data: []byte(StatusAborted.String())}); err != nil {
 		return err
 	}
 
@@ -129,7 +129,7 @@ func (w *microWorkflow) Suspend(ctx context.Context, id string) error {
 
 	// Обновляем статус в хранилище - это приостановит выполнение в любом сервисе
 	// так как handleWorkflow проверяет статус перед каждым шагом
-	if err := workflowStore.Write(ctx, "status", &codec.Frame{Data: []byte(StatusSuspend.String())}); err != nil {
+	if err := workflowStore.Write(ctx, "status", &codecpb.Frame{Data: []byte(StatusSuspend.String())}); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func (w *microWorkflow) Resume(ctx context.Context, id string) error {
 	workflowStore := store.NewNamespaceStore(w.opts.Store, filepath.Join("workflows", id))
 
 	// Получаем последний выполненный шаг чтобы продолжить с него
-	lastStepFrame := &codec.Frame{}
+	lastStepFrame := &codecpb.Frame{}
 	var startID string
 
 	if err := workflowStore.Read(ctx, "last_step", lastStepFrame); err == nil && len(lastStepFrame.Data) > 0 {
@@ -182,7 +182,7 @@ func (w *microWorkflow) Resume(ctx context.Context, id string) error {
 	if startID == "" {
 		vertices := w.g.GetVertices()
 		for stepID := range vertices {
-			stepStatusFrame := &codec.Frame{}
+			stepStatusFrame := &codecpb.Frame{}
 			stepPath := filepath.Join("steps", id, stepID, "status")
 			if err := workflowStore.Read(ctx, stepPath, stepStatusFrame); err != nil {
 				// Шаг еще не выполнялся, можно начать с него
@@ -202,11 +202,11 @@ func (w *microWorkflow) Resume(ctx context.Context, id string) error {
 
 	if startID == "" {
 		// Нет шагов для выполнения, помечаем как завершенный
-		return workflowStore.Write(ctx, "status", &codec.Frame{Data: []byte(StatusSuccess.String())})
+		return workflowStore.Write(ctx, "status", &codecpb.Frame{Data: []byte(StatusSuccess.String())})
 	}
 
 	// Обновляем статус на Running
-	if err := workflowStore.Write(ctx, "status", &codec.Frame{Data: []byte(StatusRunning.String())}); err != nil {
+	if err := workflowStore.Write(ctx, "status", &codecpb.Frame{Data: []byte(StatusRunning.String())}); err != nil {
 		return err
 	}
 
@@ -256,7 +256,7 @@ func (w *microWorkflow) Execute(ctx context.Context, req *Message, opts ...Execu
 	)
 	nopts = append(nopts, opts...)
 
-	if werr := workflowStore.Write(ctx, "status", &codec.Frame{Data: []byte(StatusRunning.String())}); werr != nil {
+	if werr := workflowStore.Write(ctx, "status", &codecpb.Frame{Data: []byte(StatusRunning.String())}); werr != nil {
 		w.opts.Logger.Error(ctx, "store error: %v", werr)
 		return eid, werr
 	}
@@ -316,7 +316,7 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 	failWorkflow := func(err error) error {
 		w.opts.Logger.Error(options.Context, "workflow failed: %v", err)
 
-		if werr := workflowStore.Write(options.Context, "status", &codec.Frame{Data: []byte(StatusFailure.String())}); werr != nil {
+		if werr := workflowStore.Write(options.Context, "status", &codecpb.Frame{Data: []byte(StatusFailure.String())}); werr != nil {
 			w.opts.Logger.Error(options.Context, "store error: %v", werr)
 		}
 
@@ -332,7 +332,7 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 				continue
 			}
 			w.opts.Logger.Info(options.Context, "compensating step: %s", stepID)
-			reqFrame := &codec.Frame{}
+			reqFrame := &codecpb.Frame{}
 			if rerr := stepStore.Read(options.Context, filepath.Join(stepID, "req"), reqFrame); rerr != nil {
 				w.opts.Logger.Error(options.Context, "failed to read request for compensation: %v", rerr)
 				continue
@@ -341,7 +341,7 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 			if cerr := step.Compensate(options.Context, req, opts...); cerr != nil {
 				w.opts.Logger.Error(options.Context, "compensation failed for step %s: %v", stepID, cerr)
 			} else {
-				if werr := stepStore.Write(options.Context, filepath.Join(stepID, "status"), &codec.Frame{Data: []byte(StatusPending.String())}); werr != nil {
+				if werr := stepStore.Write(options.Context, filepath.Join(stepID, "status"), &codecpb.Frame{Data: []byte(StatusPending.String())}); werr != nil {
 					w.opts.Logger.Error(options.Context, "store error: %v", werr)
 				}
 			}
@@ -409,10 +409,10 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 				}
 
 				// Resume support: skip steps that already completed successfully.
-				stepStatusFrame := &codec.Frame{}
+				stepStatusFrame := &codecpb.Frame{}
 				if rerr := stepStore.Read(execCtx, filepath.Join(id, "status"), stepStatusFrame); rerr == nil {
 					if StringStatus[string(stepStatusFrame.Data)] == StatusSuccess {
-						rspFrame := &codec.Frame{}
+						rspFrame := &codecpb.Frame{}
 						if rrerr := stepStore.Read(execCtx, filepath.Join(id, "rsp"), rspFrame); rrerr == nil && len(rspFrame.Data) > 0 {
 							resultsMu.Lock()
 							stepResults[id] = &Message{Body: rspFrame.Data}
@@ -436,14 +436,14 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 					resultsMu.RUnlock()
 				}
 
-				if werr := stepStore.Write(execCtx, filepath.Join(id, "req"), &codec.Frame{Data: inputMsg.Body}); werr != nil {
+				if werr := stepStore.Write(execCtx, filepath.Join(id, "req"), &codecpb.Frame{Data: inputMsg.Body}); werr != nil {
 					aborted.Store(true)
 					errChan <- werr
 					return
 				}
 
 				step.SetStatus(StatusRunning)
-				if werr := stepStore.Write(execCtx, filepath.Join(id, "status"), &codec.Frame{Data: []byte(StatusRunning.String())}); werr != nil {
+				if werr := stepStore.Write(execCtx, filepath.Join(id, "status"), &codecpb.Frame{Data: []byte(StatusRunning.String())}); werr != nil {
 					aborted.Store(true)
 					errChan <- werr
 					return
@@ -454,8 +454,8 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 				rsp, execErr := step.Execute(execCtx, inputMsg, opts...)
 				if execErr != nil {
 					step.SetStatus(StatusFailure)
-					_ = stepStore.Write(execCtx, filepath.Join(id, "rsp"), &codec.Frame{Data: []byte(execErr.Error())})
-					_ = stepStore.Write(execCtx, filepath.Join(id, "status"), &codec.Frame{Data: []byte(StatusFailure.String())})
+					_ = stepStore.Write(execCtx, filepath.Join(id, "rsp"), &codecpb.Frame{Data: []byte(execErr.Error())})
+					_ = stepStore.Write(execCtx, filepath.Join(id, "status"), &codecpb.Frame{Data: []byte(StatusFailure.String())})
 					aborted.Store(true)
 					errChan <- execErr
 					return
@@ -463,7 +463,7 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 
 				step.SetStatus(StatusSuccess)
 				if rsp != nil {
-					if werr := stepStore.Write(execCtx, filepath.Join(id, "rsp"), &codec.Frame{Data: rsp.Body}); werr != nil {
+					if werr := stepStore.Write(execCtx, filepath.Join(id, "rsp"), &codecpb.Frame{Data: rsp.Body}); werr != nil {
 						aborted.Store(true)
 						errChan <- werr
 						return
@@ -473,13 +473,13 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 					resultsMu.Unlock()
 				}
 
-				if werr := stepStore.Write(execCtx, filepath.Join(id, "status"), &codec.Frame{Data: []byte(StatusSuccess.String())}); werr != nil {
+				if werr := stepStore.Write(execCtx, filepath.Join(id, "status"), &codecpb.Frame{Data: []byte(StatusSuccess.String())}); werr != nil {
 					aborted.Store(true)
 					errChan <- werr
 					return
 				}
 
-				_ = workflowStore.Write(execCtx, "last_step", &codec.Frame{Data: []byte(id)})
+				_ = workflowStore.Write(execCtx, "last_step", &codecpb.Frame{Data: []byte(id)})
 
 				execMu.Lock()
 				executedSteps = append(executedSteps, id)
@@ -504,7 +504,7 @@ func (w *microWorkflow) handleWorkflow(startID string, opts ...ExecuteOption) er
 		}
 	}
 
-	if werr := workflowStore.Write(options.Context, "status", &codec.Frame{Data: []byte(StatusSuccess.String())}); werr != nil {
+	if werr := workflowStore.Write(options.Context, "status", &codecpb.Frame{Data: []byte(StatusSuccess.String())}); werr != nil {
 		w.opts.Logger.Error(options.Context, "store error: %v", werr)
 	}
 
@@ -614,7 +614,7 @@ func (f *microFlow) WorkflowSave(ctx context.Context, w Workflow) error {
 	workflowStore := store.NewNamespaceStore(f.opts.Store, filepath.Join("workflows", w.ID()))
 
 	// Сохраняем статус workflow
-	statusFrame := &codec.Frame{Data: []byte(w.Status().String())}
+	statusFrame := &codecpb.Frame{Data: []byte(w.Status().String())}
 	if err := workflowStore.Write(ctx, "status", statusFrame); err != nil {
 		return err
 	}
@@ -630,7 +630,7 @@ func (f *microFlow) WorkflowSave(ctx context.Context, w Workflow) error {
 		return err
 	}
 
-	stepFrame := &codec.Frame{Data: stepData}
+	stepFrame := &codecpb.Frame{Data: stepData}
 	if err := workflowStore.Write(ctx, "steps", stepFrame); err != nil {
 		return err
 	}
@@ -643,7 +643,7 @@ func (f *microFlow) WorkflowLoad(ctx context.Context, id string) (Workflow, erro
 	workflowStore := store.NewNamespaceStore(f.opts.Store, filepath.Join("workflows", id))
 
 	// Читаем статус
-	statusFrame := &codec.Frame{}
+	statusFrame := &codecpb.Frame{}
 	if err := workflowStore.Read(ctx, "status", statusFrame); err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (f *microFlow) WorkflowLoad(ctx context.Context, id string) (Workflow, erro
 	}
 
 	// Читаем информацию о шагах
-	stepFrame := &codec.Frame{}
+	stepFrame := &codecpb.Frame{}
 	if err := workflowStore.Read(ctx, "steps", stepFrame); err != nil {
 		f.opts.Logger.Warn(ctx, "failed to read steps for workflow %s: %v", id, err)
 		return nil, err
@@ -777,7 +777,7 @@ func (s *microCallStep) Execute(ctx context.Context, req *Message, opts ...Execu
 	if options.Client == nil {
 		return nil, ErrMissingClient
 	}
-	rsp := &codec.Frame{}
+	rsp := &codecpb.Frame{}
 	copts := []client.CallOption{client.WithRetries(0)}
 	if options.Timeout > 0 {
 		copts = append(copts,
@@ -785,7 +785,7 @@ func (s *microCallStep) Execute(ctx context.Context, req *Message, opts ...Execu
 			client.WithDialTimeout(options.Timeout))
 	}
 	nctx := metadata.NewOutgoingContext(ctx, req.Header)
-	err := options.Client.Call(nctx, options.Client.NewRequest(s.service, s.method, &codec.Frame{Data: req.Body}), rsp, copts...)
+	err := options.Client.Call(nctx, options.Client.NewRequest(s.service, s.method, &codecpb.Frame{Data: req.Body}), rsp, copts...)
 	if err != nil {
 		return nil, err
 	}

--- a/logger/options.go
+++ b/logger/options.go
@@ -48,8 +48,8 @@ type Options struct {
 	Level Level
 	// AddSource enabled writing source file and position in log
 	AddSource bool
-	// AddStacktrace controls writing of stacktaces on error
-	AddStacktrace bool
+	// AddStacktrace controls writing of stacktraces at or above the given level; NoneLevel disables it
+	AddStacktrace Level
 	// DedupKeys deduplicate keys in log output
 	DedupKeys bool
 }
@@ -65,6 +65,7 @@ func NewOptions(opts ...Option) Options {
 		AddSource:        true,
 		TimeFunc:         time.Now,
 		Meter:            meter.DefaultMeter,
+		AddStacktrace:    NoneLevel,
 	}
 
 	WithMicroKeys()(&options)
@@ -111,10 +112,10 @@ func WithOutput(out io.Writer) Option {
 	}
 }
 
-// WithStacktrace controls writing stacktrace on error
-func WithStacktrace(v bool) Option {
+// WithAddStacktrace enables stacktrace logging at or above the given level; use NoneLevel to disable
+func WithAddStacktrace(level Level) Option {
 	return func(o *Options) {
-		o.AddStacktrace = v
+		o.AddStacktrace = level
 	}
 }
 

--- a/logger/slog/slog.go
+++ b/logger/slog/slog.go
@@ -309,7 +309,7 @@ func (s *slogLogger) printLog(ctx context.Context, lvl logger.Level, msg string,
 		}
 	}
 
-	if s.opts.AddStacktrace {
+	if s.opts.AddStacktrace.Enabled(lvl) {
 		stackBuf := stackPool.Get()
 		if stackSize := runtime.Stack(*stackBuf, false); stackSize > 0 {
 			traceLines := reTrace.Split(string((*stackBuf)[:stackSize]), -1)

--- a/logger/slog/slog_test.go
+++ b/logger/slog/slog_test.go
@@ -22,7 +22,7 @@ func TestStacktrace(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	l := NewLogger(logger.WithLevel(logger.DebugLevel), logger.WithOutput(buf),
 		WithHandlerFunc(slog.NewTextHandler),
-		logger.WithStacktrace(true),
+		logger.WithAddStacktrace(logger.TraceLevel),
 		logger.WithSource(true),
 	)
 	if err := l.Init(logger.WithFields("key1", "val1")); err != nil {
@@ -59,7 +59,7 @@ func TestNoneLevel(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	l := NewLogger(logger.WithLevel(logger.NoneLevel), logger.WithOutput(buf),
 		WithHandlerFunc(slog.NewTextHandler),
-		logger.WithStacktrace(true),
+		logger.WithAddStacktrace(logger.TraceLevel),
 	)
 	if err := l.Init(logger.WithFields("key1", "val1")); err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestTime(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	l := NewLogger(logger.WithLevel(logger.ErrorLevel), logger.WithOutput(buf),
 		WithHandlerFunc(slog.NewTextHandler),
-		logger.WithStacktrace(true),
+		logger.WithAddStacktrace(logger.TraceLevel),
 		logger.WithTimeFunc(func() time.Time {
 			return time.Unix(0, 0).UTC()
 		}),
@@ -241,7 +241,7 @@ func TestMultipleFields(t *testing.T) {
 func TestError(t *testing.T) {
 	ctx := context.TODO()
 	buf := bytes.NewBuffer(nil)
-	l := NewLogger(logger.WithLevel(logger.ErrorLevel), logger.WithOutput(buf), logger.WithStacktrace(true))
+	l := NewLogger(logger.WithLevel(logger.ErrorLevel), logger.WithOutput(buf), logger.WithAddStacktrace(logger.TraceLevel))
 	if err := l.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestErrorf(t *testing.T) {
 	ctx := context.TODO()
 
 	buf := bytes.NewBuffer(nil)
-	l := NewLogger(logger.WithLevel(logger.ErrorLevel), logger.WithOutput(buf), logger.WithStacktrace(true))
+	l := NewLogger(logger.WithLevel(logger.ErrorLevel), logger.WithOutput(buf), logger.WithAddStacktrace(logger.TraceLevel))
 	if err := l.Init(logger.WithContextAttrFuncs(func(_ context.Context) []any {
 		return nil
 	})); err != nil {

--- a/util/test/test.go
+++ b/util/test/test.go
@@ -19,6 +19,7 @@ import (
 	"go.unistack.org/micro/v5/client"
 	"go.unistack.org/micro/v5/codec"
 	"go.unistack.org/micro/v5/errors"
+	codecpb "go.unistack.org/micro-proto/v5/codec"
 	"go.unistack.org/micro/v5/metadata"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/status"
@@ -55,7 +56,7 @@ var (
 
 		testMap := make(map[string]any)
 		switch v := testRsp.(type) {
-		case *codec.Frame:
+		case *codecpb.Frame:
 			if err = testCodec.Unmarshal(v.Data, &testMap); err != nil {
 				return fmt.Errorf("failed to unmarshal err: %w", err)
 			}
@@ -166,12 +167,12 @@ func CSVColumnParser(s string) []byte {
 	return []byte(s)
 }
 
-func NewResponseFromFile(rspfile string) (*codec.Frame, error) {
+func NewResponseFromFile(rspfile string) (*codecpb.Frame, error) {
 	rspbuf, err := os.ReadFile(rspfile)
 	if err != nil {
 		return nil, err
 	}
-	return &codec.Frame{Data: rspbuf}, nil
+	return &codecpb.Frame{Data: rspbuf}, nil
 }
 
 func getCodec(codecs map[string]codec.Codec, ext string) (codec.Codec, error) {
@@ -226,7 +227,7 @@ func NewRequestFromFile(c client.Client, reqfile string) (client.Request, error)
 		return nil, err
 	}
 
-	req := c.NewRequest("test", endpoint, &codec.Frame{Data: reqbuf}, client.RequestContentType(ct))
+	req := c.NewRequest("test", endpoint, &codecpb.Frame{Data: reqbuf}, client.RequestContentType(ct))
 
 	return req, nil
 }
@@ -372,7 +373,7 @@ func Run(ctx context.Context, c client.Client, m sqlmock.Sqlmock, dir string, ex
 				}
 			}()
 
-			data := &codec.Frame{}
+			data := &codecpb.Frame{}
 			md := metadata.New(1)
 			md.Set("X-Request-Id", xrid)
 			cerr := c.Call(metadata.NewOutgoingContext(gctx, md), treq, data, client.WithContentType(treq.ContentType()))


### PR DESCRIPTION
## Summary

Implements [#227](https://github.com/unistack-org/micro/issues/227) — level-aware stacktrace control for the logger.

- **`AddStacktrace bool` → `AddStacktrace Level`** in `Options`: stacktraces are now captured only when the log level meets or exceeds the configured threshold. `NoneLevel` (the default) disables stacktraces — no behaviour change for code that didn't previously enable them.
- **`WithStacktrace` → `WithAddStacktrace(level Level)`**: renamed to match the field name, accepts a `Level` instead of `bool`.
- **Check uses `Level.Enabled(lvl)`**: consistent with `V()` semantics — `s.opts.AddStacktrace.Enabled(lvl)` returns `lvl >= threshold`.
- **`codec.Frame` → `codecpb.Frame`** in `flow/default.go` and `util/test/test.go`, using `go.unistack.org/micro-proto/v5/codec`.

## Usage

```go
// stacktrace only for Error and Fatal
logger.WithAddStacktrace(logger.ErrorLevel)

// stacktrace for all levels
logger.WithAddStacktrace(logger.TraceLevel)

// disabled (default)
logger.WithAddStacktrace(logger.NoneLevel)
```

## Test plan

- [x] `go test ./logger/slog/...` passes
- [x] `go build ./flow/...` passes
- [x] `go build ./util/test/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)