### PR TITLE
feat(meter/mock): add strict expectations-based mock for meter.Meter

### DIFF
--- a/broker/mock/example_test.go
+++ b/broker/mock/example_test.go
@@ -28,7 +28,7 @@ func Example() {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":1}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":1}`), nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	_ = b.Publish(ctx, "results")
@@ -88,7 +88,7 @@ func ExampleMockBroker_InjectMessage() {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":7}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":7}`), nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	_ = sub.Unsubscribe(ctx)

--- a/broker/mock/mock.go
+++ b/broker/mock/mock.go
@@ -396,7 +396,7 @@ func (m *MockBroker) NewMessage(ctx context.Context, hdr metadata.Metadata, body
 	if err != nil {
 		return nil, err
 	}
-	return &mockMessage{ctx: ctx, hdr: hdr, body: b, c: c}, nil
+	return &MockMessage{ctx: ctx, hdr: hdr, body: b, c: c}, nil
 }
 
 // Init implements broker.Broker.

--- a/broker/mock/mock_message.go
+++ b/broker/mock/mock_message.go
@@ -4,40 +4,53 @@ package mock
 import (
 	"context"
 
-	"go.unistack.org/micro/v5/broker"
 	"go.unistack.org/micro/v5/codec"
 	"go.unistack.org/micro/v5/metadata"
 )
 
-type mockMessage struct {
+// MockMessage is a broker.Message implementation for use in tests.
+// It tracks whether Ack was called so tests can assert handler behaviour.
+type MockMessage struct {
 	ctx   context.Context
 	topic string
 	hdr   metadata.Metadata
 	body  []byte
 	c     codec.Codec
 	err   error
+	acked bool
 }
 
-func (m *mockMessage) Context() context.Context  { return m.ctx }
-func (m *mockMessage) Topic() string             { return m.topic }
-func (m *mockMessage) Header() metadata.Metadata { return m.hdr }
-func (m *mockMessage) Body() []byte              { return m.body }
-func (m *mockMessage) Ack() error                { return nil }
-func (m *mockMessage) Error() error              { return m.err }
+// Context implements broker.Message.
+func (m *MockMessage) Context() context.Context { return m.ctx }
 
-func (m *mockMessage) Unmarshal(dst any, opts ...codec.Option) error {
+// Topic implements broker.Message.
+func (m *MockMessage) Topic() string { return m.topic }
+
+// Header implements broker.Message.
+func (m *MockMessage) Header() metadata.Metadata { return m.hdr }
+
+// Body implements broker.Message.
+func (m *MockMessage) Body() []byte { return m.body }
+
+// Ack implements broker.Message. Records that the message was acknowledged.
+func (m *MockMessage) Ack() error { m.acked = true; return nil }
+
+// Error implements broker.Message.
+func (m *MockMessage) Error() error { return m.err }
+
+// Acked reports whether Ack was called on this message.
+func (m *MockMessage) Acked() bool { return m.acked }
+
+// Unmarshal implements broker.Message.
+func (m *MockMessage) Unmarshal(dst any, opts ...codec.Option) error {
 	if m.c == nil {
 		return codec.ErrUnknownContentType
 	}
 	return m.c.Unmarshal(m.body, dst, opts...)
 }
 
-// NewMockMessage creates a broker.Message with pre-marshaled body for use with InjectMessage.
-// Optionally pass a codec to enable Unmarshal in the handler under test.
-func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte, c ...codec.Codec) broker.Message {
-	msg := &mockMessage{ctx: ctx, topic: topic, hdr: hdr, body: body}
-	if len(c) > 0 {
-		msg.c = c[0]
-	}
-	return msg
+// NewMockMessage creates a MockMessage with pre-marshaled body for use with InjectMessage.
+// Pass a non-nil codec to enable Unmarshal in the handler under test.
+func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte, c codec.Codec) *MockMessage {
+	return &MockMessage{ctx: ctx, topic: topic, hdr: hdr, body: body, c: c}
 }

--- a/broker/mock/mock_test.go
+++ b/broker/mock/mock_test.go
@@ -16,7 +16,7 @@ func TestNewMockMessage(t *testing.T) {
 	hdr := metadata.Metadata{"key": []string{"val"}}
 	body := []byte(`{"id":1}`)
 
-	msg := mock.NewMockMessage(ctx, "orders", hdr, body)
+	msg := mock.NewMockMessage(ctx, "orders", hdr, body, nil)
 
 	if msg.Topic() != "orders" {
 		t.Fatalf("want topic %q, got %q", "orders", msg.Topic())
@@ -272,7 +272,7 @@ func TestInjectMessage_SingleHandler(t *testing.T) {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"x": []string{"y"}}, []byte(`{}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"x": []string{"y"}}, []byte(`{}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestInjectMessage_BatchHandler(t *testing.T) {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":2}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":2}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestInjectMessage_NoHandlers(t *testing.T) {
 	ctx := context.Background()
 	b := mock.NewMockBroker()
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, []byte(`{}`))
+	msg := mock.NewMockMessage(ctx, "orders", nil, []byte(`{}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage with no handlers should return nil, got: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestInjectMessage_HandlerError(t *testing.T) {
 	want := fmt.Errorf("handler error")
 	_, _ = b.Subscribe(ctx, "orders", func(broker.Message) error { return want })
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, nil)
+	msg := mock.NewMockMessage(ctx, "orders", nil, nil, nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != want {
 		t.Fatalf("want %v, got %v", want, err)
 	}
@@ -397,7 +397,7 @@ func TestUnsubscribe_RemovesHandler(t *testing.T) {
 	})
 	_ = sub.Unsubscribe(ctx)
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, nil)
+	msg := mock.NewMockMessage(ctx, "orders", nil, nil, nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	if called {
@@ -428,7 +428,7 @@ func TestFullLifecycle(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":42}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":42}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}

--- a/docs/superpowers/plans/2026-05-16-broker-mock.md
+++ b/docs/superpowers/plans/2026-05-16-broker-mock.md
@@ -14,14 +14,14 @@
 
 | File | Responsibility |
 |---|---|
-| `broker/mock/mock_message.go` | `mockMessage` (implements `broker.Message`), `NewMockMessage` factory |
+| `broker/mock/mock_message.go` | `MockMessage` (exported, implements `broker.Message`, tracks `Acked()`), `NewMockMessage` factory |
 | `broker/mock/mock.go` | `MockBroker`, `MockSubscriber`, all `Expected*` types, `expectation` interface |
 | `broker/mock/mock_test.go` | All tests (package `mock_test`) |
 | `broker/mock/example_test.go` | Godoc `Example_*` functions (package `mock_test`) |
 
 ---
 
-### Task 1: mockMessage
+### Task 1: MockMessage
 
 **Files:**
 - Create: `broker/mock/mock_message.go`
@@ -49,7 +49,7 @@ func TestNewMockMessage(t *testing.T) {
 	hdr := metadata.Metadata{"key": "val"}
 	body := []byte(`{"id":1}`)
 
-	msg := mock.NewMockMessage(ctx, "orders", hdr, body)
+	msg := mock.NewMockMessage(ctx, "orders", hdr, body, nil)
 
 	if msg.Topic() != "orders" {
 		t.Fatalf("want topic %q, got %q", "orders", msg.Topic())
@@ -60,11 +60,14 @@ func TestNewMockMessage(t *testing.T) {
 	if msg.Context() != ctx {
 		t.Fatal("context mismatch")
 	}
-	if v, ok := msg.Header()["key"]; !ok || v != "val" {
+	if v, ok := msg.Header()["key"]; !ok || len(v) == 0 || v[0] != "val" {
 		t.Fatal("header mismatch")
 	}
 	if err := msg.Ack(); err != nil {
 		t.Fatalf("Ack: %v", err)
+	}
+	if !msg.Acked() {
+		t.Fatal("Acked should be true after Ack")
 	}
 	if err := msg.Error(); err != nil {
 		t.Fatalf("Error: %v", err)
@@ -94,37 +97,37 @@ import (
 	"go.unistack.org/micro/v5/metadata"
 )
 
-type mockMessage struct {
+// MockMessage is a broker.Message implementation for use in tests.
+// It tracks whether Ack was called so tests can assert handler behaviour.
+type MockMessage struct {
 	ctx   context.Context
 	topic string
 	hdr   metadata.Metadata
 	body  []byte
 	c     codec.Codec
 	err   error
+	acked bool
 }
 
-func (m *mockMessage) Context() context.Context  { return m.ctx }
-func (m *mockMessage) Topic() string             { return m.topic }
-func (m *mockMessage) Header() metadata.Metadata { return m.hdr }
-func (m *mockMessage) Body() []byte              { return m.body }
-func (m *mockMessage) Ack() error                { return nil }
-func (m *mockMessage) Error() error              { return m.err }
+func (m *MockMessage) Context() context.Context  { return m.ctx }
+func (m *MockMessage) Topic() string             { return m.topic }
+func (m *MockMessage) Header() metadata.Metadata { return m.hdr }
+func (m *MockMessage) Body() []byte              { return m.body }
+func (m *MockMessage) Ack() error                { m.acked = true; return nil }
+func (m *MockMessage) Acked() bool               { return m.acked }
+func (m *MockMessage) Error() error              { return m.err }
 
-func (m *mockMessage) Unmarshal(dst any, opts ...codec.Option) error {
+func (m *MockMessage) Unmarshal(dst any, opts ...codec.Option) error {
 	if m.c == nil {
 		return codec.ErrUnknownContentType
 	}
 	return m.c.Unmarshal(m.body, dst, opts...)
 }
 
-// NewMockMessage creates a broker.Message with pre-marshaled body for use with InjectMessage.
-// Optionally pass a codec to enable Unmarshal in the handler under test.
-func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte, c ...codec.Codec) broker.Message {
-	msg := &mockMessage{ctx: ctx, topic: topic, hdr: hdr, body: body}
-	if len(c) > 0 {
-		msg.c = c[0]
-	}
-	return msg
+// NewMockMessage creates a MockMessage with pre-marshaled body for use with InjectMessage.
+// Pass a non-nil codec to enable Unmarshal in the handler under test.
+func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte, c codec.Codec) *MockMessage {
+	return &MockMessage{ctx: ctx, topic: topic, hdr: hdr, body: body, c: c}
 }
 ```
 
@@ -140,7 +143,7 @@ Expected: PASS
 
 ```bash
 git add broker/mock/mock_message.go broker/mock/mock_test.go
-git commit -m "feat(broker/mock): add mockMessage and NewMockMessage"
+git commit -m "feat(broker/mock): add MockMessage and NewMockMessage"
 ```
 
 ---
@@ -553,7 +556,7 @@ func (m *MockBroker) NewMessage(ctx context.Context, hdr metadata.Metadata, body
 	if err != nil {
 		return nil, err
 	}
-	return &mockMessage{ctx: ctx, hdr: hdr, body: b, c: c}, nil
+	return &MockMessage{ctx: ctx, hdr: hdr, body: b, c: c}, nil
 }
 
 // Init implements broker.Broker.
@@ -961,7 +964,7 @@ func TestInjectMessage_SingleHandler(t *testing.T) {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"x": "y"}, []byte(`{}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"x": "y"}, []byte(`{}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}
@@ -987,7 +990,7 @@ func TestInjectMessage_BatchHandler(t *testing.T) {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":2}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":2}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}
@@ -1000,7 +1003,7 @@ func TestInjectMessage_NoHandlers(t *testing.T) {
 	ctx := context.Background()
 	b := mock.NewMockBroker()
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, []byte(`{}`))
+	msg := mock.NewMockMessage(ctx, "orders", nil, []byte(`{}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage with no handlers should return nil, got: %v", err)
 	}
@@ -1016,7 +1019,7 @@ func TestInjectMessage_HandlerError(t *testing.T) {
 	want := fmt.Errorf("handler error")
 	_, _ = b.Subscribe(ctx, "orders", func(broker.Message) error { return want })
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, nil)
+	msg := mock.NewMockMessage(ctx, "orders", nil, nil, nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != want {
 		t.Fatalf("want %v, got %v", want, err)
 	}
@@ -1114,7 +1117,7 @@ func TestUnsubscribe_RemovesHandler(t *testing.T) {
 	})
 	_ = sub.Unsubscribe(ctx)
 
-	msg := mock.NewMockMessage(ctx, "orders", nil, nil)
+	msg := mock.NewMockMessage(ctx, "orders", nil, nil, nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	if called {
@@ -1176,7 +1179,7 @@ func TestFullLifecycle(t *testing.T) {
 	}
 
 	// inject a message — handler receives it
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":42}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":42}`), nil)
 	if err := b.InjectMessage(ctx, "orders", msg); err != nil {
 		t.Fatalf("InjectMessage: %v", err)
 	}
@@ -1262,7 +1265,7 @@ func Example() {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":1}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":1}`), nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	_ = b.Publish(ctx, "results")
@@ -1322,7 +1325,7 @@ func ExampleMockBroker_InjectMessage() {
 		return nil
 	})
 
-	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":7}`))
+	msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{}, []byte(`{"id":7}`), nil)
 	_ = b.InjectMessage(ctx, "orders", msg)
 
 	_ = sub.Unsubscribe(ctx)

--- a/docs/superpowers/plans/2026-05-16-meter-mock.md
+++ b/docs/superpowers/plans/2026-05-16-meter-mock.md
@@ -1,0 +1,1428 @@
+# meter/mock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `go.unistack.org/micro/v5/meter/mock` — a strict expectations-based mock of the `meter.Meter` interface for use in tests.
+
+**Architecture:** `MockMeter` holds an ordered slice of `expectation` values registered via `ExpectXxx()` methods. On each method call the mock scans for the first untriggered matching expectation, marks it triggered, and returns configured values. Unexpected calls (no matching expectation) are recorded and reported by `ExpectationsWereMet()`. Sub-interface types (`mockCounter`, `mockGauge`, etc.) accumulate real values so tests can inspect them via `exp.Counter().Get()`.
+
+**Tech Stack:** Go 1.26, `go.unistack.org/micro/v5/meter`, `sync`, `fmt`, `io`, `time`
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `meter/mock/mock.go` | Create | `MockMeter`, all `Expected*` types, all `mock*` sub-interface types |
+| `meter/mock/mock_test.go` | Create | All tests (grows with each task) |
+
+---
+
+### Task 1: Package scaffold
+
+Create the two files. `mock.go` contains `MockMeter` satisfying `meter.Meter` with all methods stubbed (no expectation dispatch yet), plus all five sub-interface mock types. `mock_test.go` has only a compile-time assertion test.
+
+**Files:**
+- Create: `meter/mock/mock.go`
+- Create: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `meter/mock/mock_test.go`:
+
+```go
+package mock
+
+import (
+	"testing"
+
+	"go.unistack.org/micro/v5/meter"
+)
+
+func TestMockMeter_Implements(t *testing.T) {
+	var _ meter.Meter = NewMockMeter()
+}
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd /Users/vtolstov/Projects/unistack/micro/micro
+go test ./meter/mock/... -v -count=1
+```
+
+Expected: `cannot find package` or `undefined: NewMockMeter`
+
+- [ ] **Step 3: Create `meter/mock/mock.go` with the scaffold**
+
+```go
+// Package mock provides a strict expectations-based mock of meter.Meter.
+package mock
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"go.unistack.org/micro/v5/meter"
+)
+
+// Compile-time interface check.
+var _ meter.Meter = (*MockMeter)(nil)
+
+// expectation is the common interface for all Expected* types.
+type expectation interface {
+	fulfilled() bool
+	Lock()
+	Unlock()
+	String() string
+}
+
+// commonExpectation is embedded in all Expected* types.
+type commonExpectation struct {
+	sync.Mutex
+	triggered bool
+	err       error
+}
+
+func (e *commonExpectation) fulfilled() bool { return e.triggered }
+
+// MockMeter is a mock implementation of meter.Meter for use in tests.
+//
+// Register expectations with ExpectInit, ExpectCounter, etc. before exercising
+// the code under test. After the test call ExpectationsWereMet to verify all
+// declared expectations were fulfilled.
+type MockMeter struct {
+	opts       meter.Options
+	mu         sync.Mutex
+	expected   []expectation
+	unexpected []string
+}
+
+// NewMockMeter creates a new MockMeter.
+func NewMockMeter(opts ...meter.Option) *MockMeter {
+	return &MockMeter{opts: meter.NewOptions(opts...)}
+}
+
+// Name implements meter.Meter.
+func (m *MockMeter) Name() string { return m.opts.Name }
+
+// Options implements meter.Meter.
+func (m *MockMeter) Options() meter.Options { return m.opts }
+
+// String implements meter.Meter.
+func (m *MockMeter) String() string { return "mock" }
+
+// Clone implements meter.Meter. Returns the same MockMeter without requiring an expectation.
+func (m *MockMeter) Clone(_ ...meter.Option) meter.Meter { return m }
+
+// Set implements meter.Meter. Returns the same MockMeter without requiring an expectation.
+func (m *MockMeter) Set(_ ...meter.Option) meter.Meter { return m }
+
+// Init implements meter.Meter.
+func (m *MockMeter) Init(_ ...meter.Option) error {
+	return fmt.Errorf("unexpected call to meter.Init")
+}
+
+// Write implements meter.Meter.
+func (m *MockMeter) Write(_ io.Writer, _ ...meter.Option) error {
+	return fmt.Errorf("unexpected call to meter.Write")
+}
+
+// Counter implements meter.Meter.
+func (m *MockMeter) Counter(name string, _ ...string) meter.Counter {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Counter(%q)", name))
+	m.mu.Unlock()
+	return &mockCounter{}
+}
+
+// FloatCounter implements meter.Meter.
+func (m *MockMeter) FloatCounter(name string, _ ...string) meter.FloatCounter {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("FloatCounter(%q)", name))
+	m.mu.Unlock()
+	return &mockFloatCounter{}
+}
+
+// Gauge implements meter.Meter.
+func (m *MockMeter) Gauge(name string, _ func() float64, _ ...string) meter.Gauge {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Gauge(%q)", name))
+	m.mu.Unlock()
+	return &mockGauge{}
+}
+
+// Histogram implements meter.Meter.
+func (m *MockMeter) Histogram(name string, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Histogram(%q)", name))
+	m.mu.Unlock()
+	return &mockHistogram{}
+}
+
+// HistogramExt implements meter.Meter.
+func (m *MockMeter) HistogramExt(name string, _ []float64, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("HistogramExt(%q)", name))
+	m.mu.Unlock()
+	return &mockHistogram{}
+}
+
+// Summary implements meter.Meter.
+func (m *MockMeter) Summary(name string, _ ...string) meter.Summary {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Summary(%q)", name))
+	m.mu.Unlock()
+	return &mockSummary{}
+}
+
+// SummaryExt implements meter.Meter.
+func (m *MockMeter) SummaryExt(name string, _ time.Duration, _ []float64, _ ...string) meter.Summary {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("SummaryExt(%q)", name))
+	m.mu.Unlock()
+	return &mockSummary{}
+}
+
+// Unregister implements meter.Meter.
+func (m *MockMeter) Unregister(name string, _ ...string) bool {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Unregister(%q)", name))
+	m.mu.Unlock()
+	return false
+}
+
+// ExpectationsWereMet returns an error if any declared expectation was not fulfilled
+// or if there were unexpected calls.
+func (m *MockMeter) ExpectationsWereMet() error {
+	return nil // implemented in Task 8
+}
+
+// --- Sub-interface mock types ---
+
+// mockCounter is a state-tracking implementation of meter.Counter.
+type mockCounter struct {
+	mu    sync.Mutex
+	value uint64
+}
+
+func (c *mockCounter) Add(v int) {
+	c.mu.Lock()
+	if v >= 0 {
+		c.value += uint64(v)
+	} else {
+		u := uint64(-v)
+		if u <= c.value {
+			c.value -= u
+		} else {
+			c.value = 0
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *mockCounter) Dec() { c.mu.Lock(); if c.value > 0 { c.value-- }; c.mu.Unlock() }
+func (c *mockCounter) Inc() { c.mu.Lock(); c.value++; c.mu.Unlock() }
+func (c *mockCounter) Get() uint64 { c.mu.Lock(); defer c.mu.Unlock(); return c.value }
+func (c *mockCounter) Set(v uint64) { c.mu.Lock(); c.value = v; c.mu.Unlock() }
+
+// mockFloatCounter is a state-tracking implementation of meter.FloatCounter.
+type mockFloatCounter struct {
+	mu    sync.Mutex
+	value float64
+}
+
+func (c *mockFloatCounter) Add(v float64) { c.mu.Lock(); c.value += v; c.mu.Unlock() }
+func (c *mockFloatCounter) Sub(v float64) { c.mu.Lock(); c.value -= v; c.mu.Unlock() }
+func (c *mockFloatCounter) Get() float64  { c.mu.Lock(); defer c.mu.Unlock(); return c.value }
+func (c *mockFloatCounter) Set(v float64) { c.mu.Lock(); c.value = v; c.mu.Unlock() }
+
+// mockGauge is a state-tracking implementation of meter.Gauge.
+type mockGauge struct {
+	mu    sync.Mutex
+	value float64
+}
+
+func (g *mockGauge) Add(v float64) { g.mu.Lock(); g.value += v; g.mu.Unlock() }
+func (g *mockGauge) Set(v float64) { g.mu.Lock(); g.value = v; g.mu.Unlock() }
+func (g *mockGauge) Inc()          { g.mu.Lock(); g.value++; g.mu.Unlock() }
+func (g *mockGauge) Dec()          { g.mu.Lock(); g.value--; g.mu.Unlock() }
+func (g *mockGauge) Get() float64  { g.mu.Lock(); defer g.mu.Unlock(); return g.value }
+
+// mockHistogram is a state-tracking implementation of meter.Histogram.
+type mockHistogram struct {
+	mu      sync.Mutex
+	updates []float64
+}
+
+func (h *mockHistogram) Reset()                     { h.mu.Lock(); h.updates = nil; h.mu.Unlock() }
+func (h *mockHistogram) Update(v float64)           { h.mu.Lock(); h.updates = append(h.updates, v); h.mu.Unlock() }
+func (h *mockHistogram) UpdateDuration(t time.Time) { h.Update(time.Since(t).Seconds()) }
+
+// Updates returns a copy of the recorded observation values.
+func (h *mockHistogram) Updates() []float64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]float64, len(h.updates))
+	copy(out, h.updates)
+	return out
+}
+
+// mockSummary is a state-tracking implementation of meter.Summary.
+type mockSummary struct {
+	mu      sync.Mutex
+	updates []float64
+}
+
+func (s *mockSummary) Update(v float64)           { s.mu.Lock(); s.updates = append(s.updates, v); s.mu.Unlock() }
+func (s *mockSummary) UpdateDuration(t time.Time) { s.Update(time.Since(t).Seconds()) }
+
+// Updates returns a copy of the recorded observation values.
+func (s *mockSummary) Updates() []float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]float64, len(s.updates))
+	copy(out, s.updates)
+	return out
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1
+```
+
+Expected: `PASS TestMockMeter_Implements`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add package scaffold with sub-interface mocks"
+```
+
+---
+
+### Task 2: Init expectation
+
+Add `ExpectedInit`, `ExpectInit()`, and update `Init()` dispatch.
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+import (
+	"errors"
+	"testing"
+
+	"go.unistack.org/micro/v5/meter"
+)
+
+func TestMockMeter_Init_Success(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	if err := m.Init(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_Init_Error(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit().WillReturnError(errors.New("init failed"))
+	err := m.Init()
+	if err == nil || err.Error() != "init failed" {
+		t.Fatalf("expected 'init failed', got %v", err)
+	}
+}
+
+func TestMockMeter_Init_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if err := m.Init(); err == nil {
+		t.Fatal("expected error for unexpected Init call")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run TestMockMeter_Init
+```
+
+Expected: `undefined: ExpectInit` (compile error)
+
+- [ ] **Step 3: Add `ExpectedInit` and `ExpectInit()` to `mock.go`, update `Init()`**
+
+After the `commonExpectation` definition, add:
+
+```go
+// ExpectedInit holds an expectation for meter.Init.
+type ExpectedInit struct {
+	commonExpectation
+}
+
+// WillReturnError configures the error returned by Init.
+func (e *ExpectedInit) WillReturnError(err error) *ExpectedInit { e.err = err; return e }
+
+func (e *ExpectedInit) String() string {
+	if e.err != nil {
+		return fmt.Sprintf("ExpectedInit => should return error: %s", e.err)
+	}
+	return "ExpectedInit"
+}
+```
+
+Add `ExpectInit()` method to `MockMeter`:
+
+```go
+// ExpectInit registers an expectation that meter.Init will be called.
+func (m *MockMeter) ExpectInit() *ExpectedInit {
+	e := &ExpectedInit{}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace the `Init` method body:
+
+```go
+// Init implements meter.Meter.
+func (m *MockMeter) Init(_ ...meter.Option) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ei, ok := e.(*ExpectedInit)
+		if !ok {
+			continue
+		}
+		ei.Lock()
+		if ei.triggered {
+			ei.Unlock()
+			continue
+		}
+		ei.triggered = true
+		err := ei.err
+		ei.Unlock()
+		return err
+	}
+	return fmt.Errorf("unexpected call to meter.Init")
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run TestMockMeter_Init
+```
+
+Expected: all three `TestMockMeter_Init_*` tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Init expectation"
+```
+
+---
+
+### Task 3: Counter, FloatCounter, Gauge expectations
+
+Add `ExpectedCounter`, `ExpectedFloatCounter`, `ExpectedGauge` types plus their `ExpectXxx()` methods and dispatch updates.
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_Counter(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectCounter("requests", "method", "GET")
+
+	c := m.Counter("requests", "method", "GET")
+	c.Inc()
+	c.Inc()
+	c.Add(3)
+	c.Dec()
+	c.Set(10)
+
+	if got := exp.Counter().Get(); got != 10 {
+		t.Fatalf("expected 10, got %d", got)
+	}
+}
+
+func TestMockMeter_Counter_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	_ = m.Counter("hits") // no expectation — goes to unexpected
+	if len(m.unexpected) == 0 {
+		t.Fatal("expected unexpected call to be recorded")
+	}
+}
+
+func TestMockMeter_FloatCounter(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectFloatCounter("bytes")
+
+	fc := m.FloatCounter("bytes")
+	fc.Add(1.5)
+	fc.Add(2.5)
+	fc.Sub(1.0)
+	fc.Set(5.0)
+
+	if got := exp.FloatCounter().Get(); got != 5.0 {
+		t.Fatalf("expected 5.0, got %f", got)
+	}
+}
+
+func TestMockMeter_Gauge(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectGauge("temperature")
+
+	g := m.Gauge("temperature", nil)
+	g.Set(42.0)
+	g.Inc()
+	g.Dec()
+	g.Add(0.5)
+
+	if got := exp.Gauge().Get(); got != 42.5 {
+		t.Fatalf("expected 42.5, got %f", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_(Counter|FloatCounter|Gauge)'
+```
+
+Expected: `undefined: ExpectCounter` (compile error)
+
+- [ ] **Step 3: Add Expected types and Expect methods to `mock.go`**
+
+After `ExpectedInit`, add:
+
+```go
+// ExpectedCounter holds an expectation for meter.Counter.
+type ExpectedCounter struct {
+	commonExpectation
+	name    string
+	labels  []string
+	counter *mockCounter
+}
+
+// Counter returns the mock counter for value inspection.
+func (e *ExpectedCounter) Counter() *mockCounter { return e.counter }
+
+func (e *ExpectedCounter) String() string {
+	return fmt.Sprintf("ExpectedCounter(%q)", e.name)
+}
+
+// ExpectedFloatCounter holds an expectation for meter.FloatCounter.
+type ExpectedFloatCounter struct {
+	commonExpectation
+	name         string
+	labels       []string
+	floatCounter *mockFloatCounter
+}
+
+// FloatCounter returns the mock float counter for value inspection.
+func (e *ExpectedFloatCounter) FloatCounter() *mockFloatCounter { return e.floatCounter }
+
+func (e *ExpectedFloatCounter) String() string {
+	return fmt.Sprintf("ExpectedFloatCounter(%q)", e.name)
+}
+
+// ExpectedGauge holds an expectation for meter.Gauge.
+type ExpectedGauge struct {
+	commonExpectation
+	name   string
+	labels []string
+	gauge  *mockGauge
+}
+
+// Gauge returns the mock gauge for value inspection.
+func (e *ExpectedGauge) Gauge() *mockGauge { return e.gauge }
+
+func (e *ExpectedGauge) String() string {
+	return fmt.Sprintf("ExpectedGauge(%q)", e.name)
+}
+```
+
+Add `ExpectCounter`, `ExpectFloatCounter`, `ExpectGauge` methods to `MockMeter`:
+
+```go
+// ExpectCounter registers an expectation that meter.Counter will be called with name.
+func (m *MockMeter) ExpectCounter(name string, labels ...string) *ExpectedCounter {
+	e := &ExpectedCounter{name: name, labels: labels, counter: &mockCounter{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectFloatCounter registers an expectation that meter.FloatCounter will be called with name.
+func (m *MockMeter) ExpectFloatCounter(name string, labels ...string) *ExpectedFloatCounter {
+	e := &ExpectedFloatCounter{name: name, labels: labels, floatCounter: &mockFloatCounter{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectGauge registers an expectation that meter.Gauge will be called with name.
+func (m *MockMeter) ExpectGauge(name string, labels ...string) *ExpectedGauge {
+	e := &ExpectedGauge{name: name, labels: labels, gauge: &mockGauge{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace `Counter`, `FloatCounter`, `Gauge` method bodies:
+
+```go
+// Counter implements meter.Meter.
+func (m *MockMeter) Counter(name string, _ ...string) meter.Counter {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ec, ok := e.(*ExpectedCounter)
+		if !ok {
+			continue
+		}
+		ec.Lock()
+		if ec.triggered || ec.name != name {
+			ec.Unlock()
+			continue
+		}
+		ec.triggered = true
+		c := ec.counter
+		ec.Unlock()
+		return c
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Counter(%q)", name))
+	return &mockCounter{}
+}
+
+// FloatCounter implements meter.Meter.
+func (m *MockMeter) FloatCounter(name string, _ ...string) meter.FloatCounter {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ec, ok := e.(*ExpectedFloatCounter)
+		if !ok {
+			continue
+		}
+		ec.Lock()
+		if ec.triggered || ec.name != name {
+			ec.Unlock()
+			continue
+		}
+		ec.triggered = true
+		fc := ec.floatCounter
+		ec.Unlock()
+		return fc
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("FloatCounter(%q)", name))
+	return &mockFloatCounter{}
+}
+
+// Gauge implements meter.Meter.
+func (m *MockMeter) Gauge(name string, _ func() float64, _ ...string) meter.Gauge {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eg, ok := e.(*ExpectedGauge)
+		if !ok {
+			continue
+		}
+		eg.Lock()
+		if eg.triggered || eg.name != name {
+			eg.Unlock()
+			continue
+		}
+		eg.triggered = true
+		g := eg.gauge
+		eg.Unlock()
+		return g
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Gauge(%q)", name))
+	return &mockGauge{}
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_(Counter|FloatCounter|Gauge)'
+```
+
+Expected: all five tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Counter, FloatCounter, Gauge expectations"
+```
+
+---
+
+### Task 4: Histogram and HistogramExt expectations
+
+Add `ExpectedHistogram`, `ExpectedHistogramExt` and their dispatch.
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_Histogram(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectHistogram("latency")
+
+	h := m.Histogram("latency")
+	h.Update(1.0)
+	h.Update(2.5)
+	h.Reset()
+	h.Update(3.0)
+
+	updates := exp.Histogram().Updates()
+	if len(updates) != 1 || updates[0] != 3.0 {
+		t.Fatalf("expected [3.0], got %v", updates)
+	}
+}
+
+func TestMockMeter_HistogramExt(t *testing.T) {
+	m := NewMockMeter()
+	quantiles := []float64{0.5, 0.9, 0.99}
+	exp := m.ExpectHistogramExt("latency_ext", quantiles)
+
+	h := m.HistogramExt("latency_ext", quantiles)
+	h.Update(1.0)
+	h.Update(2.0)
+
+	updates := exp.Histogram().Updates()
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Histogram'
+```
+
+Expected: `undefined: ExpectHistogram` (compile error)
+
+- [ ] **Step 3: Add Expected types and Expect methods to `mock.go`**
+
+After `ExpectedGauge`, add:
+
+```go
+// ExpectedHistogram holds an expectation for meter.Histogram.
+type ExpectedHistogram struct {
+	commonExpectation
+	name      string
+	labels    []string
+	histogram *mockHistogram
+}
+
+// Histogram returns the mock histogram for value inspection.
+func (e *ExpectedHistogram) Histogram() *mockHistogram { return e.histogram }
+
+func (e *ExpectedHistogram) String() string {
+	return fmt.Sprintf("ExpectedHistogram(%q)", e.name)
+}
+
+// ExpectedHistogramExt holds an expectation for meter.HistogramExt.
+type ExpectedHistogramExt struct {
+	commonExpectation
+	name      string
+	quantiles []float64
+	labels    []string
+	histogram *mockHistogram
+}
+
+// Histogram returns the mock histogram for value inspection.
+func (e *ExpectedHistogramExt) Histogram() *mockHistogram { return e.histogram }
+
+func (e *ExpectedHistogramExt) String() string {
+	return fmt.Sprintf("ExpectedHistogramExt(%q)", e.name)
+}
+```
+
+Add `ExpectHistogram` and `ExpectHistogramExt` to `MockMeter`:
+
+```go
+// ExpectHistogram registers an expectation that meter.Histogram will be called with name.
+func (m *MockMeter) ExpectHistogram(name string, labels ...string) *ExpectedHistogram {
+	e := &ExpectedHistogram{name: name, labels: labels, histogram: &mockHistogram{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectHistogramExt registers an expectation that meter.HistogramExt will be called with name.
+func (m *MockMeter) ExpectHistogramExt(name string, quantiles []float64, labels ...string) *ExpectedHistogramExt {
+	e := &ExpectedHistogramExt{name: name, quantiles: quantiles, labels: labels, histogram: &mockHistogram{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace `Histogram` and `HistogramExt` method bodies:
+
+```go
+// Histogram implements meter.Meter.
+func (m *MockMeter) Histogram(name string, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eh, ok := e.(*ExpectedHistogram)
+		if !ok {
+			continue
+		}
+		eh.Lock()
+		if eh.triggered || eh.name != name {
+			eh.Unlock()
+			continue
+		}
+		eh.triggered = true
+		h := eh.histogram
+		eh.Unlock()
+		return h
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Histogram(%q)", name))
+	return &mockHistogram{}
+}
+
+// HistogramExt implements meter.Meter.
+func (m *MockMeter) HistogramExt(name string, _ []float64, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eh, ok := e.(*ExpectedHistogramExt)
+		if !ok {
+			continue
+		}
+		eh.Lock()
+		if eh.triggered || eh.name != name {
+			eh.Unlock()
+			continue
+		}
+		eh.triggered = true
+		h := eh.histogram
+		eh.Unlock()
+		return h
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("HistogramExt(%q)", name))
+	return &mockHistogram{}
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Histogram'
+```
+
+Expected: both Histogram tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Histogram and HistogramExt expectations"
+```
+
+---
+
+### Task 5: Summary and SummaryExt expectations
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_Summary(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectSummary("response_size")
+
+	s := m.Summary("response_size")
+	s.Update(100.0)
+	s.Update(200.0)
+
+	updates := exp.Summary().Updates()
+	if len(updates) != 2 || updates[0] != 100.0 || updates[1] != 200.0 {
+		t.Fatalf("expected [100.0, 200.0], got %v", updates)
+	}
+}
+
+func TestMockMeter_SummaryExt(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectSummaryExt("response_size_ext", 5*time.Minute, []float64{0.5, 0.9})
+
+	s := m.SummaryExt("response_size_ext", 5*time.Minute, []float64{0.5, 0.9})
+	s.Update(42.0)
+
+	updates := exp.Summary().Updates()
+	if len(updates) != 1 || updates[0] != 42.0 {
+		t.Fatalf("expected [42.0], got %v", updates)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Summary'
+```
+
+Expected: `undefined: ExpectSummary` (compile error)
+
+- [ ] **Step 3: Add Expected types and Expect methods to `mock.go`**
+
+After `ExpectedHistogramExt`, add:
+
+```go
+// ExpectedSummary holds an expectation for meter.Summary.
+type ExpectedSummary struct {
+	commonExpectation
+	name    string
+	labels  []string
+	summary *mockSummary
+}
+
+// Summary returns the mock summary for value inspection.
+func (e *ExpectedSummary) Summary() *mockSummary { return e.summary }
+
+func (e *ExpectedSummary) String() string {
+	return fmt.Sprintf("ExpectedSummary(%q)", e.name)
+}
+
+// ExpectedSummaryExt holds an expectation for meter.SummaryExt.
+type ExpectedSummaryExt struct {
+	commonExpectation
+	name      string
+	window    time.Duration
+	quantiles []float64
+	labels    []string
+	summary   *mockSummary
+}
+
+// Summary returns the mock summary for value inspection.
+func (e *ExpectedSummaryExt) Summary() *mockSummary { return e.summary }
+
+func (e *ExpectedSummaryExt) String() string {
+	return fmt.Sprintf("ExpectedSummaryExt(%q)", e.name)
+}
+```
+
+Add `ExpectSummary` and `ExpectSummaryExt` to `MockMeter`:
+
+```go
+// ExpectSummary registers an expectation that meter.Summary will be called with name.
+func (m *MockMeter) ExpectSummary(name string, labels ...string) *ExpectedSummary {
+	e := &ExpectedSummary{name: name, labels: labels, summary: &mockSummary{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectSummaryExt registers an expectation that meter.SummaryExt will be called with name.
+func (m *MockMeter) ExpectSummaryExt(name string, window time.Duration, quantiles []float64, labels ...string) *ExpectedSummaryExt {
+	e := &ExpectedSummaryExt{name: name, window: window, quantiles: quantiles, labels: labels, summary: &mockSummary{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace `Summary` and `SummaryExt` method bodies:
+
+```go
+// Summary implements meter.Meter.
+func (m *MockMeter) Summary(name string, _ ...string) meter.Summary {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		es, ok := e.(*ExpectedSummary)
+		if !ok {
+			continue
+		}
+		es.Lock()
+		if es.triggered || es.name != name {
+			es.Unlock()
+			continue
+		}
+		es.triggered = true
+		s := es.summary
+		es.Unlock()
+		return s
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Summary(%q)", name))
+	return &mockSummary{}
+}
+
+// SummaryExt implements meter.Meter.
+func (m *MockMeter) SummaryExt(name string, _ time.Duration, _ []float64, _ ...string) meter.Summary {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		es, ok := e.(*ExpectedSummaryExt)
+		if !ok {
+			continue
+		}
+		es.Lock()
+		if es.triggered || es.name != name {
+			es.Unlock()
+			continue
+		}
+		es.triggered = true
+		s := es.summary
+		es.Unlock()
+		return s
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("SummaryExt(%q)", name))
+	return &mockSummary{}
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Summary'
+```
+
+Expected: both Summary tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Summary and SummaryExt expectations"
+```
+
+---
+
+### Task 6: Write expectation
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_Write_Success(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectWrite()
+	if err := m.Write(io.Discard); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_Write_Error(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectWrite().WillReturnError(errors.New("write failed"))
+	if err := m.Write(io.Discard); err == nil || err.Error() != "write failed" {
+		t.Fatalf("expected 'write failed', got %v", err)
+	}
+}
+
+func TestMockMeter_Write_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if err := m.Write(io.Discard); err == nil {
+		t.Fatal("expected error for unexpected Write call")
+	}
+}
+```
+
+Add `"io"` to the import block in `mock_test.go`:
+
+```go
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"go.unistack.org/micro/v5/meter"
+)
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Write'
+```
+
+Expected: `undefined: ExpectWrite` (compile error)
+
+- [ ] **Step 3: Add `ExpectedWrite` and update `Write()` in `mock.go`**
+
+After `ExpectedInit`, add:
+
+```go
+// ExpectedWrite holds an expectation for meter.Write.
+type ExpectedWrite struct {
+	commonExpectation
+}
+
+// WillReturnError configures the error returned by Write.
+func (e *ExpectedWrite) WillReturnError(err error) *ExpectedWrite { e.err = err; return e }
+
+func (e *ExpectedWrite) String() string {
+	if e.err != nil {
+		return fmt.Sprintf("ExpectedWrite => should return error: %s", e.err)
+	}
+	return "ExpectedWrite"
+}
+```
+
+Add `ExpectWrite()` to `MockMeter`:
+
+```go
+// ExpectWrite registers an expectation that meter.Write will be called.
+func (m *MockMeter) ExpectWrite() *ExpectedWrite {
+	e := &ExpectedWrite{}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace the `Write` method body:
+
+```go
+// Write implements meter.Meter.
+func (m *MockMeter) Write(_ io.Writer, _ ...meter.Option) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ew, ok := e.(*ExpectedWrite)
+		if !ok {
+			continue
+		}
+		ew.Lock()
+		if ew.triggered {
+			ew.Unlock()
+			continue
+		}
+		ew.triggered = true
+		err := ew.err
+		ew.Unlock()
+		return err
+	}
+	return fmt.Errorf("unexpected call to meter.Write")
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Write'
+```
+
+Expected: all three Write tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Write expectation"
+```
+
+---
+
+### Task 7: Unregister expectation
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_Unregister_True(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectUnregister("old_metric").WillReturn(true)
+	if !m.Unregister("old_metric") {
+		t.Fatal("expected true")
+	}
+}
+
+func TestMockMeter_Unregister_False(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectUnregister("missing").WillReturn(false)
+	if m.Unregister("missing") {
+		t.Fatal("expected false")
+	}
+}
+
+func TestMockMeter_Unregister_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if m.Unregister("anything") {
+		t.Fatal("expected false for unexpected call")
+	}
+	if len(m.unexpected) == 0 {
+		t.Fatal("expected unexpected call to be recorded")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Unregister'
+```
+
+Expected: `undefined: ExpectUnregister` (compile error)
+
+- [ ] **Step 3: Add `ExpectedUnregister` and update `Unregister()` in `mock.go`**
+
+After `ExpectedWrite`, add:
+
+```go
+// ExpectedUnregister holds an expectation for meter.Unregister.
+type ExpectedUnregister struct {
+	commonExpectation
+	name   string
+	labels []string
+	result bool
+}
+
+// WillReturn configures the bool returned by Unregister.
+func (e *ExpectedUnregister) WillReturn(v bool) *ExpectedUnregister { e.result = v; return e }
+
+func (e *ExpectedUnregister) String() string {
+	return fmt.Sprintf("ExpectedUnregister(%q)", e.name)
+}
+```
+
+Add `ExpectUnregister()` to `MockMeter`:
+
+```go
+// ExpectUnregister registers an expectation that meter.Unregister will be called with name.
+func (m *MockMeter) ExpectUnregister(name string, labels ...string) *ExpectedUnregister {
+	e := &ExpectedUnregister{name: name, labels: labels}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+```
+
+Replace the `Unregister` method body:
+
+```go
+// Unregister implements meter.Meter.
+func (m *MockMeter) Unregister(name string, _ ...string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eu, ok := e.(*ExpectedUnregister)
+		if !ok {
+			continue
+		}
+		eu.Lock()
+		if eu.triggered || eu.name != name {
+			eu.Unlock()
+			continue
+		}
+		eu.triggered = true
+		result := eu.result
+		eu.Unlock()
+		return result
+	}
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Unregister(%q)", name))
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_Unregister'
+```
+
+Expected: all three Unregister tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): add Unregister expectation"
+```
+
+---
+
+### Task 8: ExpectationsWereMet
+
+Implement `ExpectationsWereMet()` to report unfulfilled expectations and unexpected calls.
+
+**Files:**
+- Modify: `meter/mock/mock.go`
+- Modify: `meter/mock/mock_test.go`
+
+- [ ] **Step 1: Add tests to `mock_test.go`**
+
+Append to `mock_test.go`:
+
+```go
+func TestMockMeter_ExpectationsWereMet_OK(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	m.ExpectCounter("hits")
+
+	_ = m.Init()
+	_ = m.Counter("hits")
+
+	if err := m.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_ExpectationsWereMet_Unfulfilled(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	// Never call Init — expectation remains unfulfilled.
+
+	if err := m.ExpectationsWereMet(); err == nil {
+		t.Fatal("expected error for unfulfilled expectation")
+	}
+}
+
+func TestMockMeter_ExpectationsWereMet_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	_ = m.Counter("unregistered") // no expectation
+
+	if err := m.ExpectationsWereMet(); err == nil {
+		t.Fatal("expected error for unexpected call")
+	}
+}
+
+func TestMockMeter_CloneSet(t *testing.T) {
+	m := NewMockMeter(meter.Name("base"))
+	c := m.Clone()
+	if c == nil {
+		t.Fatal("Clone returned nil")
+	}
+	s := m.Set()
+	if s == nil {
+		t.Fatal("Set returned nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+go test ./meter/mock/... -v -count=1 -run 'TestMockMeter_ExpectationsWereMet|TestMockMeter_CloneSet'
+```
+
+Expected: `TestMockMeter_ExpectationsWereMet_Unfulfilled` and `TestMockMeter_ExpectationsWereMet_Unexpected` fail because `ExpectationsWereMet` currently returns `nil`.
+
+- [ ] **Step 3: Replace `ExpectationsWereMet()` body in `mock.go`**
+
+```go
+// ExpectationsWereMet returns an error if any declared expectation was not fulfilled
+// or if there were unexpected calls.
+func (m *MockMeter) ExpectationsWereMet() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		e.Lock()
+		fulfilled := e.fulfilled()
+		e.Unlock()
+		if !fulfilled {
+			return fmt.Errorf("there is a remaining expectation which was not matched: %s", e)
+		}
+	}
+	if len(m.unexpected) > 0 {
+		return fmt.Errorf("there were unexpected calls: %v", m.unexpected)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all tests — expect pass**
+
+```bash
+go test ./meter/mock/... -v -count=1
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add meter/mock/mock.go meter/mock/mock_test.go
+git commit -m "feat(meter/mock): implement ExpectationsWereMet"
+```
+
+---
+
+## Self-review against spec
+
+**Spec coverage:**
+
+| Spec requirement | Covered by |
+|-----------------|------------|
+| `MockMeter` implementing `meter.Meter` | Task 1 |
+| `ExpectInit` + `WillReturnError` | Task 2 |
+| `ExpectWrite` + `WillReturnError` | Task 6 |
+| `ExpectUnregister` + `WillReturn(bool)` | Task 7 |
+| `ExpectCounter` + `Counter()` inspection | Task 3 |
+| `ExpectFloatCounter` + `FloatCounter()` inspection | Task 3 |
+| `ExpectGauge` + `Gauge()` inspection | Task 3 |
+| `ExpectHistogram` + `Histogram()` inspection | Task 4 |
+| `ExpectHistogramExt` + `Histogram()` inspection | Task 4 |
+| `ExpectSummary` + `Summary()` inspection | Task 5 |
+| `ExpectSummaryExt` + `Summary()` inspection | Task 5 |
+| Unexpected calls recorded + reported | Tasks 1, 8 |
+| `ExpectationsWereMet()` | Task 8 |
+| `Clone()` / `Set()` without expectation | Task 8 |
+| Compile-time `var _ meter.Meter` check | Task 1 |
+
+**No placeholders found.**
+
+**Type consistency:** `exp.Counter()` returns `*mockCounter`, `exp.Histogram()` returns `*mockHistogram`, `exp.Summary()` returns `*mockSummary` — consistent throughout all tasks. `Updates()` helper exists on both `mockHistogram` and `mockSummary`.

--- a/docs/superpowers/specs/2026-05-16-broker-mock-design.md
+++ b/docs/superpowers/specs/2026-05-16-broker-mock-design.md
@@ -18,7 +18,7 @@ Strict expectation-based mock: every `Connect`, `Disconnect`, `Publish`, `Subscr
 ```
 micro/broker/mock/
 ├── mock.go          # MockBroker, MockSubscriber, expectation types, commonExpectation
-└── mock_message.go  # mockMessage — implements broker.Message for InjectMessage
+└── mock_message.go  # MockMessage — implements broker.Message for InjectMessage, exported for assertions
 ```
 
 ## Types
@@ -122,19 +122,27 @@ func (s *MockSubscriber) Unsubscribe(ctx context.Context) error
 
 `Unsubscribe` looks up the first unfulfilled `ExpectedUnsubscribe` for the topic, removes the handler from `m.handlers[topic]`, and marks the expectation as triggered. Returns an error if no matching expectation is found.
 
-### mockMessage
+### MockMessage
 
-Implements `broker.Message`. Used for constructing messages passed to `InjectMessage`.
+Exported type implementing `broker.Message`. Used for constructing messages passed to `InjectMessage`. Tracks whether `Ack` was called, allowing tests to assert handler acknowledgement behaviour.
 
 ```go
-type mockMessage struct {
+type MockMessage struct {
     ctx   context.Context
     topic string
     hdr   metadata.Metadata
     body  []byte
+    c     codec.Codec
+    err   error
+    acked bool
 }
 
-func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte) broker.Message
+func (m *MockMessage) Ack() error    // sets m.acked = true
+func (m *MockMessage) Acked() bool   // returns whether Ack was called
+
+// NewMockMessage creates a MockMessage with pre-marshaled body.
+// Pass a non-nil codec to enable Unmarshal in the handler under test.
+func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, body []byte, c codec.Codec) *MockMessage
 ```
 
 ## Behaviour per Method
@@ -147,7 +155,7 @@ func NewMockMessage(ctx context.Context, topic string, hdr metadata.Metadata, bo
 | `Subscribe` | Finds first unfulfilled `ExpectedSubscribe` matching topic. Missing → error. If `e.err != nil`, returns `nil, e.err` without registering handler. Otherwise registers handler in `m.handlers[topic]` and returns `MockSubscriber, nil`. |
 | `Unsubscribe` | Finds first unfulfilled `ExpectedUnsubscribe` matching topic. Missing → error. Removes handler from `m.handlers[topic]`. |
 | `InjectMessage` | Calls all handlers in `m.handlers[topic]` with `msg`. Supports both `func(broker.Message) error` and `func([]broker.Message) error`. Returns first error. |
-| `NewMessage` | Creates a `mockMessage`; does not require a prior expectation. |
+| `NewMessage` | Creates a `MockMessage` via codec marshal; does not require a prior expectation. |
 | `Name/String/Live/Ready/Health/Address/Options` | Simple getters; no expectation required. |
 
 ## Error Cases
@@ -187,7 +195,7 @@ mock.ExpectDisconnect()
 _ = mock.Connect(ctx)
 myService.StartConsumer(ctx, mock)
 
-msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"key": "val"}, []byte(`{}`))
+msg := mock.NewMockMessage(ctx, "orders", metadata.Metadata{"key": "val"}, []byte(`{}`), nil)
 err := mock.InjectMessage(ctx, "orders", msg)
 assert.NoError(t, err)
 

--- a/docs/superpowers/specs/2026-05-16-meter-mock-design.md
+++ b/docs/superpowers/specs/2026-05-16-meter-mock-design.md
@@ -1,0 +1,209 @@
+# Design: meter/mock — строгий мок для meter.Meter
+
+**Дата:** 2026-05-16  
+**Модуль:** `go.unistack.org/micro/v5`  
+**Путь:** `meter/mock/mock.go`, `meter/mock/mock_test.go`
+
+---
+
+## Цель
+
+Реализовать мок-имплементацию интерфейса `meter.Meter` в пакете `go.unistack.org/micro/v5/meter/mock` по аналогии с `broker/mock`. Мок должен позволять:
+
+1. Регистрировать ожидания на методы Meter (`ExpectCounter(...)`, `ExpectInit()` и т.д.)
+2. Проверять, что все ожидания были выполнены через `ExpectationsWereMet()`
+3. Инспектировать фактически накопленные значения метрик (Counter, Gauge и т.д.)
+4. Возвращать ошибку на неожиданные вызовы (для методов, возвращающих `error`)
+
+---
+
+## Интерфейс meter.Meter (справка)
+
+```go
+type Meter interface {
+    Name() string
+    Init(opts ...Option) error
+    Clone(opts ...Option) Meter
+    Counter(name string, labels ...string) Counter
+    FloatCounter(name string, labels ...string) FloatCounter
+    Gauge(name string, fn func() float64, labels ...string) Gauge
+    Set(opts ...Option) Meter
+    Histogram(name string, labels ...string) Histogram
+    HistogramExt(name string, quantiles []float64, labels ...string) Histogram
+    Summary(name string, labels ...string) Summary
+    SummaryExt(name string, window time.Duration, quantiles []float64, labels ...string) Summary
+    Write(w io.Writer, opts ...Option) error
+    Options() Options
+    String() string
+    Unregister(name string, labels ...string) bool
+}
+```
+
+---
+
+## Архитектура
+
+### Базовая инфраструктура ожиданий (как в broker/mock)
+
+```go
+// expectation — общий интерфейс для всех Expected*
+type expectation interface {
+    fulfilled() bool
+    Lock()
+    Unlock()
+    String() string
+}
+
+// commonExpectation — встраивается во все Expected-типы
+type commonExpectation struct {
+    sync.Mutex
+    triggered bool
+    err       error
+}
+
+func (e *commonExpectation) fulfilled() bool { return e.triggered }
+```
+
+### Expected-типы
+
+| Тип | Метод Meter | Fluent-методы |
+|-----|-------------|---------------|
+| `ExpectedInit` | `Init()` | `WillReturnError(err)` |
+| `ExpectedWrite` | `Write()` | `WillReturnError(err)` |
+| `ExpectedUnregister` | `Unregister(name, labels...)` | `WillReturn(bool)` |
+| `ExpectedCounter` | `Counter(name, labels...)` | содержит `*mockCounter` |
+| `ExpectedFloatCounter` | `FloatCounter(name, labels...)` | содержит `*mockFloatCounter` |
+| `ExpectedGauge` | `Gauge(name, fn, labels...)` | содержит `*mockGauge` |
+| `ExpectedHistogram` | `Histogram(name, labels...)` | содержит `*mockHistogram` |
+| `ExpectedHistogramExt` | `HistogramExt(name, quantiles, labels...)` | содержит `*mockHistogram` |
+| `ExpectedSummary` | `Summary(name, labels...)` | содержит `*mockSummary` |
+| `ExpectedSummaryExt` | `SummaryExt(name, window, quantiles, labels...)` | содержит `*mockSummary` |
+
+### Мок-объекты метрик (state-tracking)
+
+Каждый мок-объект субинтерфейса реализует соответствующий интерфейс `meter.*` и накапливает реальные значения:
+
+- `mockCounter` — `value uint64`, защищён `sync.Mutex`
+- `mockFloatCounter` — `value float64`, защищён `sync.Mutex`
+- `mockGauge` — `value float64`, защищён `sync.Mutex`; `fn func() float64` для `Get()` при наличии
+- `mockHistogram` — срез `updates []float64`, защищён `sync.Mutex`
+- `mockSummary` — срез `updates []float64`, защищён `sync.Mutex`
+
+Тест получает доступ через поле ожидания:
+
+```go
+exp := m.ExpectCounter("requests", "method", "GET")
+// ... тестируемый код ...
+if exp.Counter().Get() != 5 {
+    t.Errorf("expected 5, got %d", exp.Counter().Get())
+}
+```
+
+### MockMeter
+
+```go
+type MockMeter struct {
+    opts       meter.Options
+    mu         sync.Mutex
+    expected   []expectation
+    unexpected []string  // список неожиданных вызовов
+}
+
+func NewMockMeter(opts ...meter.Option) *MockMeter
+```
+
+**Поведение при вызовах:**
+
+- Первое подходящее незатронутое ожидание срабатывает и помечается `triggered = true`
+- Если подходящего ожидания нет:
+  - `Init()`, `Write()` → `fmt.Errorf("unexpected call to ...")`
+  - `Counter()`, `FloatCounter()`, `Gauge()`, `Histogram()`, `Summary()` → noop-объект + запись в `unexpected`
+  - `Unregister()` → `false` + запись в `unexpected`
+- `Clone()` и `Set()` → возвращают тот же `*MockMeter` (без необходимости регистрировать ожидание)
+
+### ExpectationsWereMet()
+
+```go
+func (m *MockMeter) ExpectationsWereMet() error
+```
+
+Возвращает ошибку если:
+1. Хотя бы одно ожидание не было выполнено (`triggered == false`)
+2. Были неожиданные вызовы (непустой `unexpected`)
+
+---
+
+## Файлы
+
+```
+meter/
+  mock/
+    mock.go       — MockMeter, Expected*, mock*Counter/Gauge/Histogram/Summary
+    mock_test.go  — тесты: Init, Counter.Inc, Histogram.Update, ExpectationsWereMet
+```
+
+---
+
+## Примеры использования
+
+```go
+// Базовый сценарий
+m := mock.NewMockMeter()
+m.ExpectInit()
+m.ExpectCounter("requests", "method", "GET")
+
+_ = m.Init()
+c := m.Counter("requests", "method", "GET")
+c.Inc()
+c.Inc()
+
+exp := m.expected[1].(*mock.ExpectedCounter)
+if exp.Counter().Get() != 2 {
+    t.Error("expected 2 increments")
+}
+if err := m.ExpectationsWereMet(); err != nil {
+    t.Error(err)
+}
+
+// Ожидание ошибки
+m2 := mock.NewMockMeter()
+m2.ExpectInit().WillReturnError(errors.New("init failed"))
+if err := m2.Init(); err == nil {
+    t.Error("expected error")
+}
+
+// Unregister
+m3 := mock.NewMockMeter()
+m3.ExpectUnregister("old_metric").WillReturn(true)
+if !m3.Unregister("old_metric") {
+    t.Error("expected true")
+}
+```
+
+---
+
+## Тесты
+
+`mock_test.go` покрывает:
+
+1. `TestMockMeter_Init` — ожидание, ошибка, неожиданный вызов
+2. `TestMockMeter_Counter` — `Inc`, `Dec`, `Add`, `Set`, `Get` через `ExpectedCounter.Counter()`
+3. `TestMockMeter_FloatCounter` — `Add`, `Sub`, `Set`, `Get`
+4. `TestMockMeter_Gauge` — `Inc`, `Dec`, `Set`, `Get`
+5. `TestMockMeter_Histogram` — `Update`, `UpdateDuration`, `Reset`
+6. `TestMockMeter_HistogramExt` — то же что Histogram
+7. `TestMockMeter_Summary` — `Update`, `UpdateDuration`
+8. `TestMockMeter_SummaryExt` — то же что Summary
+9. `TestMockMeter_Write` — ожидание, ошибка
+10. `TestMockMeter_Unregister` — `WillReturn(true/false)`
+11. `TestMockMeter_ExpectationsWereMet` — незакрытые ожидания, неожиданные вызовы
+12. `TestMockMeter_CloneSet` — Clone и Set без ожиданий
+
+---
+
+## Соответствие стандартам проекта
+
+- Compile-time check: `var _ meter.Meter = (*MockMeter)(nil)`
+- Документация всех публичных типов и методов (обязательна по CLAUDE.md)
+- Пакет `mock`, `package mock`
+- Импорт: `go.unistack.org/micro/v5/meter`

--- a/docs/superpowers/specs/2026-05-16-meter-mock-design.md
+++ b/docs/superpowers/specs/2026-05-16-meter-mock-design.md
@@ -150,14 +150,13 @@ meter/
 // Basic scenario
 m := mock.NewMockMeter()
 m.ExpectInit()
-m.ExpectCounter("requests", "method", "GET")
+exp := m.ExpectCounter("requests", "method", "GET")
 
 _ = m.Init()
 c := m.Counter("requests", "method", "GET")
 c.Inc()
 c.Inc()
 
-exp := m.expected[1].(*mock.ExpectedCounter)
 if exp.Counter().Get() != 2 {
     t.Error("expected 2 increments")
 }

--- a/docs/superpowers/specs/2026-05-16-meter-mock-design.md
+++ b/docs/superpowers/specs/2026-05-16-meter-mock-design.md
@@ -1,23 +1,23 @@
-# Design: meter/mock — строгий мок для meter.Meter
+# Design: meter/mock — strict mock for meter.Meter
 
-**Дата:** 2026-05-16  
-**Модуль:** `go.unistack.org/micro/v5`  
-**Путь:** `meter/mock/mock.go`, `meter/mock/mock_test.go`
-
----
-
-## Цель
-
-Реализовать мок-имплементацию интерфейса `meter.Meter` в пакете `go.unistack.org/micro/v5/meter/mock` по аналогии с `broker/mock`. Мок должен позволять:
-
-1. Регистрировать ожидания на методы Meter (`ExpectCounter(...)`, `ExpectInit()` и т.д.)
-2. Проверять, что все ожидания были выполнены через `ExpectationsWereMet()`
-3. Инспектировать фактически накопленные значения метрик (Counter, Gauge и т.д.)
-4. Возвращать ошибку на неожиданные вызовы (для методов, возвращающих `error`)
+**Date:** 2026-05-16
+**Module:** `go.unistack.org/micro/v5`
+**Path:** `meter/mock/mock.go`, `meter/mock/mock_test.go`
 
 ---
 
-## Интерфейс meter.Meter (справка)
+## Goal
+
+Implement a mock of the `meter.Meter` interface in package `go.unistack.org/micro/v5/meter/mock`, following the same pattern as `broker/mock`. The mock must:
+
+1. Register expectations on Meter methods (`ExpectCounter(...)`, `ExpectInit()`, etc.)
+2. Verify all expectations were fulfilled via `ExpectationsWereMet()`
+3. Allow tests to inspect the actual accumulated metric values (Counter, Gauge, etc.)
+4. Return an error on unexpected calls to methods that return `error`
+
+---
+
+## meter.Meter interface (reference)
 
 ```go
 type Meter interface {
@@ -41,12 +41,12 @@ type Meter interface {
 
 ---
 
-## Архитектура
+## Architecture
 
-### Базовая инфраструктура ожиданий (как в broker/mock)
+### Expectation infrastructure (mirroring broker/mock)
 
 ```go
-// expectation — общий интерфейс для всех Expected*
+// expectation is the common interface for all Expected* types.
 type expectation interface {
     fulfilled() bool
     Lock()
@@ -54,7 +54,7 @@ type expectation interface {
     String() string
 }
 
-// commonExpectation — встраивается во все Expected-типы
+// commonExpectation is embedded in all Expected* types.
 type commonExpectation struct {
     sync.Mutex
     triggered bool
@@ -64,36 +64,36 @@ type commonExpectation struct {
 func (e *commonExpectation) fulfilled() bool { return e.triggered }
 ```
 
-### Expected-типы
+### Expected types
 
-| Тип | Метод Meter | Fluent-методы |
-|-----|-------------|---------------|
+| Type | Meter method | Fluent methods |
+|------|--------------|----------------|
 | `ExpectedInit` | `Init()` | `WillReturnError(err)` |
 | `ExpectedWrite` | `Write()` | `WillReturnError(err)` |
 | `ExpectedUnregister` | `Unregister(name, labels...)` | `WillReturn(bool)` |
-| `ExpectedCounter` | `Counter(name, labels...)` | содержит `*mockCounter` |
-| `ExpectedFloatCounter` | `FloatCounter(name, labels...)` | содержит `*mockFloatCounter` |
-| `ExpectedGauge` | `Gauge(name, fn, labels...)` | содержит `*mockGauge` |
-| `ExpectedHistogram` | `Histogram(name, labels...)` | содержит `*mockHistogram` |
-| `ExpectedHistogramExt` | `HistogramExt(name, quantiles, labels...)` | содержит `*mockHistogram` |
-| `ExpectedSummary` | `Summary(name, labels...)` | содержит `*mockSummary` |
-| `ExpectedSummaryExt` | `SummaryExt(name, window, quantiles, labels...)` | содержит `*mockSummary` |
+| `ExpectedCounter` | `Counter(name, labels...)` | exposes `*mockCounter` |
+| `ExpectedFloatCounter` | `FloatCounter(name, labels...)` | exposes `*mockFloatCounter` |
+| `ExpectedGauge` | `Gauge(name, fn, labels...)` | exposes `*mockGauge` |
+| `ExpectedHistogram` | `Histogram(name, labels...)` | exposes `*mockHistogram` |
+| `ExpectedHistogramExt` | `HistogramExt(name, quantiles, labels...)` | exposes `*mockHistogram` |
+| `ExpectedSummary` | `Summary(name, labels...)` | exposes `*mockSummary` |
+| `ExpectedSummaryExt` | `SummaryExt(name, window, quantiles, labels...)` | exposes `*mockSummary` |
 
-### Мок-объекты метрик (state-tracking)
+### Metric mock objects (state-tracking)
 
-Каждый мок-объект субинтерфейса реализует соответствующий интерфейс `meter.*` и накапливает реальные значения:
+Each sub-interface mock implements the corresponding `meter.*` interface and accumulates real values:
 
-- `mockCounter` — `value uint64`, защищён `sync.Mutex`
-- `mockFloatCounter` — `value float64`, защищён `sync.Mutex`
-- `mockGauge` — `value float64`, защищён `sync.Mutex`; `fn func() float64` для `Get()` при наличии
-- `mockHistogram` — срез `updates []float64`, защищён `sync.Mutex`
-- `mockSummary` — срез `updates []float64`, защищён `sync.Mutex`
+- `mockCounter` — `value uint64`, guarded by `sync.Mutex`
+- `mockFloatCounter` — `value float64`, guarded by `sync.Mutex`
+- `mockGauge` — `value float64`, guarded by `sync.Mutex`; `fn func() float64` stored for `Get()` when provided
+- `mockHistogram` — `updates []float64`, guarded by `sync.Mutex`; `Reset()` clears the slice
+- `mockSummary` — `updates []float64`, guarded by `sync.Mutex`
 
-Тест получает доступ через поле ожидания:
+Tests access the accumulated value through the expectation's field:
 
 ```go
 exp := m.ExpectCounter("requests", "method", "GET")
-// ... тестируемый код ...
+// ... run code under test ...
 if exp.Counter().Get() != 5 {
     t.Errorf("expected 5, got %d", exp.Counter().Get())
 }
@@ -106,20 +106,20 @@ type MockMeter struct {
     opts       meter.Options
     mu         sync.Mutex
     expected   []expectation
-    unexpected []string  // список неожиданных вызовов
+    unexpected []string  // unexpected call descriptions
 }
 
 func NewMockMeter(opts ...meter.Option) *MockMeter
 ```
 
-**Поведение при вызовах:**
+**Call dispatch rules:**
 
-- Первое подходящее незатронутое ожидание срабатывает и помечается `triggered = true`
-- Если подходящего ожидания нет:
+- The first untriggered matching expectation fires and is marked `triggered = true`.
+- If no matching expectation exists:
   - `Init()`, `Write()` → `fmt.Errorf("unexpected call to ...")`
-  - `Counter()`, `FloatCounter()`, `Gauge()`, `Histogram()`, `Summary()` → noop-объект + запись в `unexpected`
-  - `Unregister()` → `false` + запись в `unexpected`
-- `Clone()` и `Set()` → возвращают тот же `*MockMeter` (без необходимости регистрировать ожидание)
+  - `Counter()`, `FloatCounter()`, `Gauge()`, `Histogram()`, `Summary()` → noop object + append to `unexpected`
+  - `Unregister()` → `false` + append to `unexpected`
+- `Clone()` and `Set()` → return the same `*MockMeter` (no expectation required)
 
 ### ExpectationsWereMet()
 
@@ -127,27 +127,27 @@ func NewMockMeter(opts ...meter.Option) *MockMeter
 func (m *MockMeter) ExpectationsWereMet() error
 ```
 
-Возвращает ошибку если:
-1. Хотя бы одно ожидание не было выполнено (`triggered == false`)
-2. Были неожиданные вызовы (непустой `unexpected`)
+Returns an error if:
+1. Any registered expectation was not triggered (`triggered == false`)
+2. There were unexpected calls (non-empty `unexpected`)
 
 ---
 
-## Файлы
+## Files
 
 ```
 meter/
   mock/
-    mock.go       — MockMeter, Expected*, mock*Counter/Gauge/Histogram/Summary
-    mock_test.go  — тесты: Init, Counter.Inc, Histogram.Update, ExpectationsWereMet
+    mock.go       — MockMeter, Expected*, mockCounter/FloatCounter/Gauge/Histogram/Summary
+    mock_test.go  — tests: Init, Counter.Inc, Histogram.Update, ExpectationsWereMet, etc.
 ```
 
 ---
 
-## Примеры использования
+## Usage examples
 
 ```go
-// Базовый сценарий
+// Basic scenario
 m := mock.NewMockMeter()
 m.ExpectInit()
 m.ExpectCounter("requests", "method", "GET")
@@ -165,7 +165,7 @@ if err := m.ExpectationsWereMet(); err != nil {
     t.Error(err)
 }
 
-// Ожидание ошибки
+// Error injection
 m2 := mock.NewMockMeter()
 m2.ExpectInit().WillReturnError(errors.New("init failed"))
 if err := m2.Init(); err == nil {
@@ -182,28 +182,28 @@ if !m3.Unregister("old_metric") {
 
 ---
 
-## Тесты
+## Test coverage
 
-`mock_test.go` покрывает:
+`mock_test.go` covers:
 
-1. `TestMockMeter_Init` — ожидание, ошибка, неожиданный вызов
-2. `TestMockMeter_Counter` — `Inc`, `Dec`, `Add`, `Set`, `Get` через `ExpectedCounter.Counter()`
+1. `TestMockMeter_Init` — expectation, error injection, unexpected call
+2. `TestMockMeter_Counter` — `Inc`, `Dec`, `Add`, `Set`, `Get` via `ExpectedCounter.Counter()`
 3. `TestMockMeter_FloatCounter` — `Add`, `Sub`, `Set`, `Get`
 4. `TestMockMeter_Gauge` — `Inc`, `Dec`, `Set`, `Get`
 5. `TestMockMeter_Histogram` — `Update`, `UpdateDuration`, `Reset`
-6. `TestMockMeter_HistogramExt` — то же что Histogram
+6. `TestMockMeter_HistogramExt` — same as Histogram
 7. `TestMockMeter_Summary` — `Update`, `UpdateDuration`
-8. `TestMockMeter_SummaryExt` — то же что Summary
-9. `TestMockMeter_Write` — ожидание, ошибка
+8. `TestMockMeter_SummaryExt` — same as Summary
+9. `TestMockMeter_Write` — expectation, error injection
 10. `TestMockMeter_Unregister` — `WillReturn(true/false)`
-11. `TestMockMeter_ExpectationsWereMet` — незакрытые ожидания, неожиданные вызовы
-12. `TestMockMeter_CloneSet` — Clone и Set без ожиданий
+11. `TestMockMeter_ExpectationsWereMet` — unfulfilled expectations, unexpected calls
+12. `TestMockMeter_CloneSet` — Clone and Set without expectations
 
 ---
 
-## Соответствие стандартам проекта
+## Project standards
 
-- Compile-time check: `var _ meter.Meter = (*MockMeter)(nil)`
-- Документация всех публичных типов и методов (обязательна по CLAUDE.md)
-- Пакет `mock`, `package mock`
-- Импорт: `go.unistack.org/micro/v5/meter`
+- Compile-time interface check: `var _ meter.Meter = (*MockMeter)(nil)`
+- All public types and methods documented (required per project CLAUDE.md)
+- Package declaration: `package mock`
+- Import path: `go.unistack.org/micro/v5/meter`

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -54,6 +54,21 @@ func (e *ExpectedInit) String() string {
 	return "ExpectedInit"
 }
 
+// ExpectedWrite holds an expectation for meter.Write.
+type ExpectedWrite struct {
+	commonExpectation
+}
+
+// WillReturnError configures the error returned by Write.
+func (e *ExpectedWrite) WillReturnError(err error) *ExpectedWrite { e.err = err; return e }
+
+func (e *ExpectedWrite) String() string {
+	if e.err != nil {
+		return fmt.Sprintf("ExpectedWrite => should return error: %s", e.err)
+	}
+	return "ExpectedWrite"
+}
+
 // ExpectedCounter holds an expectation for meter.Counter.
 type ExpectedCounter struct {
 	commonExpectation
@@ -202,6 +217,15 @@ func (m *MockMeter) Set(_ ...meter.Option) meter.Meter {
 	return m
 }
 
+// ExpectWrite registers an expectation that meter.Write will be called.
+func (m *MockMeter) ExpectWrite() *ExpectedWrite {
+	e := &ExpectedWrite{}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
 // ExpectInit registers an expectation that meter.Init will be called.
 func (m *MockMeter) ExpectInit() *ExpectedInit {
 	e := &ExpectedInit{}
@@ -296,8 +320,25 @@ func (m *MockMeter) Init(_ ...meter.Option) error {
 	return fmt.Errorf("unexpected call to meter.Init")
 }
 
-// Write records an unexpected call and returns an error.
+// Write implements meter.Meter.
 func (m *MockMeter) Write(_ io.Writer, _ ...meter.Option) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ew, ok := e.(*ExpectedWrite)
+		if !ok {
+			continue
+		}
+		ew.Lock()
+		if ew.triggered {
+			ew.Unlock()
+			continue
+		}
+		ew.triggered = true
+		err := ew.err
+		ew.Unlock()
+		return err
+	}
 	return fmt.Errorf("unexpected call to meter.Write")
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -130,6 +130,38 @@ func (e *ExpectedHistogramExt) String() string {
 	return fmt.Sprintf("ExpectedHistogramExt(%q)", e.name)
 }
 
+// ExpectedSummary holds an expectation for meter.Summary.
+type ExpectedSummary struct {
+	commonExpectation
+	name    string
+	labels  []string
+	summary *mockSummary
+}
+
+// Summary returns the mock summary for value inspection.
+func (e *ExpectedSummary) Summary() *mockSummary { return e.summary }
+
+func (e *ExpectedSummary) String() string {
+	return fmt.Sprintf("ExpectedSummary(%q)", e.name)
+}
+
+// ExpectedSummaryExt holds an expectation for meter.SummaryExt.
+type ExpectedSummaryExt struct {
+	commonExpectation
+	name      string
+	window    time.Duration
+	quantiles []float64
+	labels    []string
+	summary   *mockSummary
+}
+
+// Summary returns the mock summary for value inspection.
+func (e *ExpectedSummaryExt) Summary() *mockSummary { return e.summary }
+
+func (e *ExpectedSummaryExt) String() string {
+	return fmt.Sprintf("ExpectedSummaryExt(%q)", e.name)
+}
+
 // MockMeter is a mock implementation of meter.Meter for use in tests.
 type MockMeter struct {
 	opts       meter.Options
@@ -218,6 +250,24 @@ func (m *MockMeter) ExpectHistogram(name string, labels ...string) *ExpectedHist
 // ExpectHistogramExt registers an expectation that meter.HistogramExt will be called with name.
 func (m *MockMeter) ExpectHistogramExt(name string, quantiles []float64, labels ...string) *ExpectedHistogramExt {
 	e := &ExpectedHistogramExt{name: name, quantiles: quantiles, labels: labels, histogram: &mockHistogram{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectSummary registers an expectation that meter.Summary will be called with name.
+func (m *MockMeter) ExpectSummary(name string, labels ...string) *ExpectedSummary {
+	e := &ExpectedSummary{name: name, labels: labels, summary: &mockSummary{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectSummaryExt registers an expectation that meter.SummaryExt will be called with name.
+func (m *MockMeter) ExpectSummaryExt(name string, window time.Duration, quantiles []float64, labels ...string) *ExpectedSummaryExt {
+	e := &ExpectedSummaryExt{name: name, window: window, quantiles: quantiles, labels: labels, summary: &mockSummary{}}
 	m.mu.Lock()
 	m.expected = append(m.expected, e)
 	m.mu.Unlock()
@@ -366,19 +416,49 @@ func (m *MockMeter) HistogramExt(name string, _ []float64, _ ...string) meter.Hi
 	return &mockHistogram{}
 }
 
-// Summary records the unexpected call and returns a stub summary.
+// Summary implements meter.Meter.
 func (m *MockMeter) Summary(name string, _ ...string) meter.Summary {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		es, ok := e.(*ExpectedSummary)
+		if !ok {
+			continue
+		}
+		es.Lock()
+		if es.triggered || es.name != name {
+			es.Unlock()
+			continue
+		}
+		es.triggered = true
+		s := es.summary
+		es.Unlock()
+		return s
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("Summary(%q)", name))
-	m.mu.Unlock()
 	return &mockSummary{}
 }
 
-// SummaryExt records the unexpected call and returns a stub summary.
+// SummaryExt implements meter.Meter.
 func (m *MockMeter) SummaryExt(name string, _ time.Duration, _ []float64, _ ...string) meter.Summary {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		es, ok := e.(*ExpectedSummaryExt)
+		if !ok {
+			continue
+		}
+		es.Lock()
+		if es.triggered || es.name != name {
+			es.Unlock()
+			continue
+		}
+		es.triggered = true
+		s := es.summary
+		es.Unlock()
+		return s
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("SummaryExt(%q)", name))
-	m.mu.Unlock()
 	return &mockSummary{}
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -39,6 +39,21 @@ func (e *commonExpectation) fulfilled() bool {
 	return e.triggered
 }
 
+// ExpectedInit holds an expectation for meter.Init.
+type ExpectedInit struct {
+	commonExpectation
+}
+
+// WillReturnError configures the error returned by Init.
+func (e *ExpectedInit) WillReturnError(err error) *ExpectedInit { e.err = err; return e }
+
+func (e *ExpectedInit) String() string {
+	if e.err != nil {
+		return fmt.Sprintf("ExpectedInit => should return error: %s", e.err)
+	}
+	return "ExpectedInit"
+}
+
 // MockMeter is a mock implementation of meter.Meter for use in tests.
 type MockMeter struct {
 	opts       meter.Options
@@ -79,8 +94,34 @@ func (m *MockMeter) Set(_ ...meter.Option) meter.Meter {
 	return m
 }
 
-// Init records an unexpected call and returns an error.
+// ExpectInit registers an expectation that meter.Init will be called.
+func (m *MockMeter) ExpectInit() *ExpectedInit {
+	e := &ExpectedInit{}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// Init implements meter.Meter.
 func (m *MockMeter) Init(_ ...meter.Option) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ei, ok := e.(*ExpectedInit)
+		if !ok {
+			continue
+		}
+		ei.Lock()
+		if ei.triggered {
+			ei.Unlock()
+			continue
+		}
+		ei.triggered = true
+		err := ei.err
+		ei.Unlock()
+		return err
+	}
 	return fmt.Errorf("unexpected call to meter.Init")
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -54,6 +54,51 @@ func (e *ExpectedInit) String() string {
 	return "ExpectedInit"
 }
 
+// ExpectedCounter holds an expectation for meter.Counter.
+type ExpectedCounter struct {
+	commonExpectation
+	name    string
+	labels  []string
+	counter *mockCounter
+}
+
+// Counter returns the mock counter for value inspection.
+func (e *ExpectedCounter) Counter() *mockCounter { return e.counter }
+
+func (e *ExpectedCounter) String() string {
+	return fmt.Sprintf("ExpectedCounter(%q)", e.name)
+}
+
+// ExpectedFloatCounter holds an expectation for meter.FloatCounter.
+type ExpectedFloatCounter struct {
+	commonExpectation
+	name         string
+	labels       []string
+	floatCounter *mockFloatCounter
+}
+
+// FloatCounter returns the mock float counter for value inspection.
+func (e *ExpectedFloatCounter) FloatCounter() *mockFloatCounter { return e.floatCounter }
+
+func (e *ExpectedFloatCounter) String() string {
+	return fmt.Sprintf("ExpectedFloatCounter(%q)", e.name)
+}
+
+// ExpectedGauge holds an expectation for meter.Gauge.
+type ExpectedGauge struct {
+	commonExpectation
+	name   string
+	labels []string
+	gauge  *mockGauge
+}
+
+// Gauge returns the mock gauge for value inspection.
+func (e *ExpectedGauge) Gauge() *mockGauge { return e.gauge }
+
+func (e *ExpectedGauge) String() string {
+	return fmt.Sprintf("ExpectedGauge(%q)", e.name)
+}
+
 // MockMeter is a mock implementation of meter.Meter for use in tests.
 type MockMeter struct {
 	opts       meter.Options
@@ -103,6 +148,33 @@ func (m *MockMeter) ExpectInit() *ExpectedInit {
 	return e
 }
 
+// ExpectCounter registers an expectation that meter.Counter will be called with name.
+func (m *MockMeter) ExpectCounter(name string, labels ...string) *ExpectedCounter {
+	e := &ExpectedCounter{name: name, labels: labels, counter: &mockCounter{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectFloatCounter registers an expectation that meter.FloatCounter will be called with name.
+func (m *MockMeter) ExpectFloatCounter(name string, labels ...string) *ExpectedFloatCounter {
+	e := &ExpectedFloatCounter{name: name, labels: labels, floatCounter: &mockFloatCounter{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectGauge registers an expectation that meter.Gauge will be called with name.
+func (m *MockMeter) ExpectGauge(name string, labels ...string) *ExpectedGauge {
+	e := &ExpectedGauge{name: name, labels: labels, gauge: &mockGauge{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
 // Init implements meter.Meter.
 func (m *MockMeter) Init(_ ...meter.Option) error {
 	m.mu.Lock()
@@ -130,27 +202,72 @@ func (m *MockMeter) Write(_ io.Writer, _ ...meter.Option) error {
 	return fmt.Errorf("unexpected call to meter.Write")
 }
 
-// Counter records the unexpected call and returns a stub counter.
+// Counter implements meter.Meter.
 func (m *MockMeter) Counter(name string, _ ...string) meter.Counter {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ec, ok := e.(*ExpectedCounter)
+		if !ok {
+			continue
+		}
+		ec.Lock()
+		if ec.triggered || ec.name != name {
+			ec.Unlock()
+			continue
+		}
+		ec.triggered = true
+		c := ec.counter
+		ec.Unlock()
+		return c
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("Counter(%q)", name))
-	m.mu.Unlock()
 	return &mockCounter{}
 }
 
-// FloatCounter records the unexpected call and returns a stub float counter.
+// FloatCounter implements meter.Meter.
 func (m *MockMeter) FloatCounter(name string, _ ...string) meter.FloatCounter {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		ec, ok := e.(*ExpectedFloatCounter)
+		if !ok {
+			continue
+		}
+		ec.Lock()
+		if ec.triggered || ec.name != name {
+			ec.Unlock()
+			continue
+		}
+		ec.triggered = true
+		fc := ec.floatCounter
+		ec.Unlock()
+		return fc
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("FloatCounter(%q)", name))
-	m.mu.Unlock()
 	return &mockFloatCounter{}
 }
 
-// Gauge records the unexpected call and returns a stub gauge.
+// Gauge implements meter.Meter.
 func (m *MockMeter) Gauge(name string, _ func() float64, _ ...string) meter.Gauge {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eg, ok := e.(*ExpectedGauge)
+		if !ok {
+			continue
+		}
+		eg.Lock()
+		if eg.triggered || eg.name != name {
+			eg.Unlock()
+			continue
+		}
+		eg.triggered = true
+		g := eg.gauge
+		eg.Unlock()
+		return g
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("Gauge(%q)", name))
-	m.mu.Unlock()
 	return &mockGauge{}
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -550,9 +550,22 @@ func (m *MockMeter) Unregister(name string, _ ...string) bool {
 	return false
 }
 
-// ExpectationsWereMet verifies that all registered expectations were satisfied.
-// Full implementation is added in Task 8; currently always returns nil.
+// ExpectationsWereMet returns an error if any declared expectation was not fulfilled
+// or if there were unexpected calls.
 func (m *MockMeter) ExpectationsWereMet() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		e.Lock()
+		fulfilled := e.fulfilled()
+		e.Unlock()
+		if !fulfilled {
+			return fmt.Errorf("there is a remaining expectation which was not matched: %s", e)
+		}
+	}
+	if len(m.unexpected) > 0 {
+		return fmt.Errorf("there were unexpected calls: %v", m.unexpected)
+	}
 	return nil
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -99,6 +99,37 @@ func (e *ExpectedGauge) String() string {
 	return fmt.Sprintf("ExpectedGauge(%q)", e.name)
 }
 
+// ExpectedHistogram holds an expectation for meter.Histogram.
+type ExpectedHistogram struct {
+	commonExpectation
+	name      string
+	labels    []string
+	histogram *mockHistogram
+}
+
+// Histogram returns the mock histogram for value inspection.
+func (e *ExpectedHistogram) Histogram() *mockHistogram { return e.histogram }
+
+func (e *ExpectedHistogram) String() string {
+	return fmt.Sprintf("ExpectedHistogram(%q)", e.name)
+}
+
+// ExpectedHistogramExt holds an expectation for meter.HistogramExt.
+type ExpectedHistogramExt struct {
+	commonExpectation
+	name      string
+	quantiles []float64
+	labels    []string
+	histogram *mockHistogram
+}
+
+// Histogram returns the mock histogram for value inspection.
+func (e *ExpectedHistogramExt) Histogram() *mockHistogram { return e.histogram }
+
+func (e *ExpectedHistogramExt) String() string {
+	return fmt.Sprintf("ExpectedHistogramExt(%q)", e.name)
+}
+
 // MockMeter is a mock implementation of meter.Meter for use in tests.
 type MockMeter struct {
 	opts       meter.Options
@@ -169,6 +200,24 @@ func (m *MockMeter) ExpectFloatCounter(name string, labels ...string) *ExpectedF
 // ExpectGauge registers an expectation that meter.Gauge will be called with name.
 func (m *MockMeter) ExpectGauge(name string, labels ...string) *ExpectedGauge {
 	e := &ExpectedGauge{name: name, labels: labels, gauge: &mockGauge{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectHistogram registers an expectation that meter.Histogram will be called with name.
+func (m *MockMeter) ExpectHistogram(name string, labels ...string) *ExpectedHistogram {
+	e := &ExpectedHistogram{name: name, labels: labels, histogram: &mockHistogram{}}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
+// ExpectHistogramExt registers an expectation that meter.HistogramExt will be called with name.
+func (m *MockMeter) ExpectHistogramExt(name string, quantiles []float64, labels ...string) *ExpectedHistogramExt {
+	e := &ExpectedHistogramExt{name: name, quantiles: quantiles, labels: labels, histogram: &mockHistogram{}}
 	m.mu.Lock()
 	m.expected = append(m.expected, e)
 	m.mu.Unlock()
@@ -271,19 +320,49 @@ func (m *MockMeter) Gauge(name string, _ func() float64, _ ...string) meter.Gaug
 	return &mockGauge{}
 }
 
-// Histogram records the unexpected call and returns a stub histogram.
+// Histogram implements meter.Meter.
 func (m *MockMeter) Histogram(name string, _ ...string) meter.Histogram {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eh, ok := e.(*ExpectedHistogram)
+		if !ok {
+			continue
+		}
+		eh.Lock()
+		if eh.triggered || eh.name != name {
+			eh.Unlock()
+			continue
+		}
+		eh.triggered = true
+		h := eh.histogram
+		eh.Unlock()
+		return h
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("Histogram(%q)", name))
-	m.mu.Unlock()
 	return &mockHistogram{}
 }
 
-// HistogramExt records the unexpected call and returns a stub histogram.
+// HistogramExt implements meter.Meter.
 func (m *MockMeter) HistogramExt(name string, _ []float64, _ ...string) meter.Histogram {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eh, ok := e.(*ExpectedHistogramExt)
+		if !ok {
+			continue
+		}
+		eh.Lock()
+		if eh.triggered || eh.name != name {
+			eh.Unlock()
+			continue
+		}
+		eh.triggered = true
+		h := eh.histogram
+		eh.Unlock()
+		return h
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("HistogramExt(%q)", name))
-	m.mu.Unlock()
 	return &mockHistogram{}
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -69,6 +69,21 @@ func (e *ExpectedWrite) String() string {
 	return "ExpectedWrite"
 }
 
+// ExpectedUnregister holds an expectation for meter.Unregister.
+type ExpectedUnregister struct {
+	commonExpectation
+	name   string
+	labels []string
+	result bool
+}
+
+// WillReturn configures the bool returned by Unregister.
+func (e *ExpectedUnregister) WillReturn(v bool) *ExpectedUnregister { e.result = v; return e }
+
+func (e *ExpectedUnregister) String() string {
+	return fmt.Sprintf("ExpectedUnregister(%q)", e.name)
+}
+
 // ExpectedCounter holds an expectation for meter.Counter.
 type ExpectedCounter struct {
 	commonExpectation
@@ -298,6 +313,15 @@ func (m *MockMeter) ExpectSummaryExt(name string, window time.Duration, quantile
 	return e
 }
 
+// ExpectUnregister registers an expectation that meter.Unregister will be called with name.
+func (m *MockMeter) ExpectUnregister(name string, labels ...string) *ExpectedUnregister {
+	e := &ExpectedUnregister{name: name, labels: labels}
+	m.mu.Lock()
+	m.expected = append(m.expected, e)
+	m.mu.Unlock()
+	return e
+}
+
 // Init implements meter.Meter.
 func (m *MockMeter) Init(_ ...meter.Option) error {
 	m.mu.Lock()
@@ -503,11 +527,26 @@ func (m *MockMeter) SummaryExt(name string, _ time.Duration, _ []float64, _ ...s
 	return &mockSummary{}
 }
 
-// Unregister records the unexpected call and returns false.
+// Unregister implements meter.Meter.
 func (m *MockMeter) Unregister(name string, _ ...string) bool {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.expected {
+		eu, ok := e.(*ExpectedUnregister)
+		if !ok {
+			continue
+		}
+		eu.Lock()
+		if eu.triggered || eu.name != name {
+			eu.Unlock()
+			continue
+		}
+		eu.triggered = true
+		result := eu.result
+		eu.Unlock()
+		return result
+	}
 	m.unexpected = append(m.unexpected, fmt.Sprintf("Unregister(%q)", name))
-	m.mu.Unlock()
 	return false
 }
 

--- a/meter/mock/mock.go
+++ b/meter/mock/mock.go
@@ -1,0 +1,344 @@
+// Package mock provides a mock implementation of the meter.Meter interface
+// for use in tests. It records unexpected calls and supports expectation-based
+// verification in later tasks.
+package mock
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"go.unistack.org/micro/v5/meter"
+)
+
+// Compile-time check that MockMeter satisfies the meter.Meter interface.
+var _ meter.Meter = (*MockMeter)(nil)
+
+// expectation is the interface that all expected call objects must satisfy.
+type expectation interface {
+	// fulfilled reports whether this expectation has been satisfied.
+	fulfilled() bool
+	// Lock locks the expectation's mutex.
+	Lock()
+	// Unlock unlocks the expectation's mutex.
+	Unlock()
+	// String returns a human-readable description of the expectation.
+	String() string
+}
+
+// commonExpectation holds the shared state for all expectation types.
+type commonExpectation struct {
+	sync.Mutex
+	triggered bool
+	err       error
+}
+
+// fulfilled reports whether this expectation has been triggered at least once.
+func (e *commonExpectation) fulfilled() bool {
+	return e.triggered
+}
+
+// MockMeter is a mock implementation of meter.Meter for use in tests.
+type MockMeter struct {
+	opts       meter.Options
+	mu         sync.Mutex
+	expected   []expectation
+	unexpected []string
+}
+
+// NewMockMeter creates and returns a new MockMeter configured with the given options.
+func NewMockMeter(opts ...meter.Option) *MockMeter {
+	return &MockMeter{
+		opts: meter.NewOptions(opts...),
+	}
+}
+
+// Name returns the meter name from its options.
+func (m *MockMeter) Name() string {
+	return m.opts.Name
+}
+
+// Options returns the current meter options.
+func (m *MockMeter) Options() meter.Options {
+	return m.opts
+}
+
+// String returns the string identifier for this meter implementation.
+func (m *MockMeter) String() string {
+	return "mock"
+}
+
+// Clone returns m unchanged. Expectation dispatch is added in a later task.
+func (m *MockMeter) Clone(_ ...meter.Option) meter.Meter {
+	return m
+}
+
+// Set returns m unchanged. Expectation dispatch is added in a later task.
+func (m *MockMeter) Set(_ ...meter.Option) meter.Meter {
+	return m
+}
+
+// Init records an unexpected call and returns an error.
+func (m *MockMeter) Init(_ ...meter.Option) error {
+	return fmt.Errorf("unexpected call to meter.Init")
+}
+
+// Write records an unexpected call and returns an error.
+func (m *MockMeter) Write(_ io.Writer, _ ...meter.Option) error {
+	return fmt.Errorf("unexpected call to meter.Write")
+}
+
+// Counter records the unexpected call and returns a stub counter.
+func (m *MockMeter) Counter(name string, _ ...string) meter.Counter {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Counter(%q)", name))
+	m.mu.Unlock()
+	return &mockCounter{}
+}
+
+// FloatCounter records the unexpected call and returns a stub float counter.
+func (m *MockMeter) FloatCounter(name string, _ ...string) meter.FloatCounter {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("FloatCounter(%q)", name))
+	m.mu.Unlock()
+	return &mockFloatCounter{}
+}
+
+// Gauge records the unexpected call and returns a stub gauge.
+func (m *MockMeter) Gauge(name string, _ func() float64, _ ...string) meter.Gauge {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Gauge(%q)", name))
+	m.mu.Unlock()
+	return &mockGauge{}
+}
+
+// Histogram records the unexpected call and returns a stub histogram.
+func (m *MockMeter) Histogram(name string, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Histogram(%q)", name))
+	m.mu.Unlock()
+	return &mockHistogram{}
+}
+
+// HistogramExt records the unexpected call and returns a stub histogram.
+func (m *MockMeter) HistogramExt(name string, _ []float64, _ ...string) meter.Histogram {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("HistogramExt(%q)", name))
+	m.mu.Unlock()
+	return &mockHistogram{}
+}
+
+// Summary records the unexpected call and returns a stub summary.
+func (m *MockMeter) Summary(name string, _ ...string) meter.Summary {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Summary(%q)", name))
+	m.mu.Unlock()
+	return &mockSummary{}
+}
+
+// SummaryExt records the unexpected call and returns a stub summary.
+func (m *MockMeter) SummaryExt(name string, _ time.Duration, _ []float64, _ ...string) meter.Summary {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("SummaryExt(%q)", name))
+	m.mu.Unlock()
+	return &mockSummary{}
+}
+
+// Unregister records the unexpected call and returns false.
+func (m *MockMeter) Unregister(name string, _ ...string) bool {
+	m.mu.Lock()
+	m.unexpected = append(m.unexpected, fmt.Sprintf("Unregister(%q)", name))
+	m.mu.Unlock()
+	return false
+}
+
+// ExpectationsWereMet verifies that all registered expectations were satisfied.
+// Full implementation is added in Task 8; currently always returns nil.
+func (m *MockMeter) ExpectationsWereMet() error {
+	return nil
+}
+
+// mockCounter is a thread-safe stub implementation of meter.Counter.
+type mockCounter struct {
+	mu    sync.Mutex
+	value uint64
+}
+
+// Add increments the counter by delta. Negative delta is treated as zero.
+func (c *mockCounter) Add(delta int) {
+	c.mu.Lock()
+	if delta > 0 {
+		c.value += uint64(delta)
+	}
+	c.mu.Unlock()
+}
+
+// Dec decrements the counter by one, guarding against underflow.
+func (c *mockCounter) Dec() {
+	c.mu.Lock()
+	if c.value > 0 {
+		c.value--
+	}
+	c.mu.Unlock()
+}
+
+// Inc increments the counter by one.
+func (c *mockCounter) Inc() {
+	c.mu.Lock()
+	c.value++
+	c.mu.Unlock()
+}
+
+// Get returns the current counter value.
+func (c *mockCounter) Get() uint64 {
+	c.mu.Lock()
+	v := c.value
+	c.mu.Unlock()
+	return v
+}
+
+// Set assigns an explicit value to the counter.
+func (c *mockCounter) Set(v uint64) {
+	c.mu.Lock()
+	c.value = v
+	c.mu.Unlock()
+}
+
+// mockFloatCounter is a thread-safe stub implementation of meter.FloatCounter.
+type mockFloatCounter struct {
+	mu    sync.Mutex
+	value float64
+}
+
+// Add adds delta to the counter.
+func (c *mockFloatCounter) Add(delta float64) {
+	c.mu.Lock()
+	c.value += delta
+	c.mu.Unlock()
+}
+
+// Sub subtracts delta from the counter.
+func (c *mockFloatCounter) Sub(delta float64) {
+	c.mu.Lock()
+	c.value -= delta
+	c.mu.Unlock()
+}
+
+// Get returns the current counter value.
+func (c *mockFloatCounter) Get() float64 {
+	c.mu.Lock()
+	v := c.value
+	c.mu.Unlock()
+	return v
+}
+
+// Set assigns an explicit value to the counter.
+func (c *mockFloatCounter) Set(v float64) {
+	c.mu.Lock()
+	c.value = v
+	c.mu.Unlock()
+}
+
+// mockGauge is a thread-safe stub implementation of meter.Gauge.
+type mockGauge struct {
+	mu    sync.Mutex
+	value float64
+}
+
+// Add adds delta to the gauge.
+func (g *mockGauge) Add(delta float64) {
+	g.mu.Lock()
+	g.value += delta
+	g.mu.Unlock()
+}
+
+// Set assigns an explicit value to the gauge.
+func (g *mockGauge) Set(v float64) {
+	g.mu.Lock()
+	g.value = v
+	g.mu.Unlock()
+}
+
+// Inc increments the gauge by one.
+func (g *mockGauge) Inc() {
+	g.mu.Lock()
+	g.value++
+	g.mu.Unlock()
+}
+
+// Dec decrements the gauge by one.
+func (g *mockGauge) Dec() {
+	g.mu.Lock()
+	g.value--
+	g.mu.Unlock()
+}
+
+// Get returns the current gauge value.
+func (g *mockGauge) Get() float64 {
+	g.mu.Lock()
+	v := g.value
+	g.mu.Unlock()
+	return v
+}
+
+// mockHistogram is a thread-safe stub implementation of meter.Histogram.
+type mockHistogram struct {
+	mu      sync.Mutex
+	updates []float64
+}
+
+// Reset clears all recorded updates.
+func (h *mockHistogram) Reset() {
+	h.mu.Lock()
+	h.updates = nil
+	h.mu.Unlock()
+}
+
+// Update records a new observation.
+func (h *mockHistogram) Update(v float64) {
+	h.mu.Lock()
+	h.updates = append(h.updates, v)
+	h.mu.Unlock()
+}
+
+// UpdateDuration records the elapsed seconds since t as a new observation.
+func (h *mockHistogram) UpdateDuration(t time.Time) {
+	h.Update(time.Since(t).Seconds())
+}
+
+// Updates returns a copy of all recorded observations.
+func (h *mockHistogram) Updates() []float64 {
+	h.mu.Lock()
+	cp := make([]float64, len(h.updates))
+	copy(cp, h.updates)
+	h.mu.Unlock()
+	return cp
+}
+
+// mockSummary is a thread-safe stub implementation of meter.Summary.
+type mockSummary struct {
+	mu      sync.Mutex
+	updates []float64
+}
+
+// Update records a new observation.
+func (s *mockSummary) Update(v float64) {
+	s.mu.Lock()
+	s.updates = append(s.updates, v)
+	s.mu.Unlock()
+}
+
+// UpdateDuration records the elapsed seconds since t as a new observation.
+func (s *mockSummary) UpdateDuration(t time.Time) {
+	s.Update(time.Since(t).Seconds())
+}
+
+// Updates returns a copy of all recorded observations.
+func (s *mockSummary) Updates() []float64 {
+	s.mu.Lock()
+	cp := make([]float64, len(s.updates))
+	copy(cp, s.updates)
+	s.mu.Unlock()
+	return cp
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -171,3 +171,29 @@ func TestMockMeter_Write_Unexpected(t *testing.T) {
 		t.Fatal("expected error for unexpected Write call")
 	}
 }
+
+func TestMockMeter_Unregister_True(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectUnregister("old_metric").WillReturn(true)
+	if !m.Unregister("old_metric") {
+		t.Fatal("expected true")
+	}
+}
+
+func TestMockMeter_Unregister_False(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectUnregister("missing").WillReturn(false)
+	if m.Unregister("missing") {
+		t.Fatal("expected false")
+	}
+}
+
+func TestMockMeter_Unregister_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if m.Unregister("anything") {
+		t.Fatal("expected false for unexpected call")
+	}
+	if len(m.unexpected) == 0 {
+		t.Fatal("expected unexpected call to be recorded")
+	}
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -145,5 +146,28 @@ func TestMockMeter_SummaryExt(t *testing.T) {
 	updates := exp.Summary().Updates()
 	if len(updates) != 1 || updates[0] != 42.0 {
 		t.Fatalf("expected [42.0], got %v", updates)
+	}
+}
+
+func TestMockMeter_Write_Success(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectWrite()
+	if err := m.Write(io.Discard); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_Write_Error(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectWrite().WillReturnError(errors.New("write failed"))
+	if err := m.Write(io.Discard); err == nil || err.Error() != "write failed" {
+		t.Fatalf("expected 'write failed', got %v", err)
+	}
+}
+
+func TestMockMeter_Write_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if err := m.Write(io.Discard); err == nil {
+		t.Fatal("expected error for unexpected Write call")
 	}
 }

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -88,3 +88,34 @@ func TestMockMeter_Gauge(t *testing.T) {
 		t.Fatalf("expected 42.5, got %f", got)
 	}
 }
+
+func TestMockMeter_Histogram(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectHistogram("latency")
+
+	h := m.Histogram("latency")
+	h.Update(1.0)
+	h.Update(2.5)
+	h.Reset()
+	h.Update(3.0)
+
+	updates := exp.Histogram().Updates()
+	if len(updates) != 1 || updates[0] != 3.0 {
+		t.Fatalf("expected [3.0], got %v", updates)
+	}
+}
+
+func TestMockMeter_HistogramExt(t *testing.T) {
+	m := NewMockMeter()
+	quantiles := []float64{0.5, 0.9, 0.99}
+	exp := m.ExpectHistogramExt("latency_ext", quantiles)
+
+	h := m.HistogramExt("latency_ext", quantiles)
+	h.Update(1.0)
+	h.Update(2.0)
+
+	updates := exp.Histogram().Updates()
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"go.unistack.org/micro/v5/meter"
 )
@@ -117,5 +118,32 @@ func TestMockMeter_HistogramExt(t *testing.T) {
 	updates := exp.Histogram().Updates()
 	if len(updates) != 2 {
 		t.Fatalf("expected 2 updates, got %d", len(updates))
+	}
+}
+
+func TestMockMeter_Summary(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectSummary("response_size")
+
+	s := m.Summary("response_size")
+	s.Update(100.0)
+	s.Update(200.0)
+
+	updates := exp.Summary().Updates()
+	if len(updates) != 2 || updates[0] != 100.0 || updates[1] != 200.0 {
+		t.Fatalf("expected [100.0, 200.0], got %v", updates)
+	}
+}
+
+func TestMockMeter_SummaryExt(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectSummaryExt("response_size_ext", 5*time.Minute, []float64{0.5, 0.9})
+
+	s := m.SummaryExt("response_size_ext", 5*time.Minute, []float64{0.5, 0.9})
+	s.Update(42.0)
+
+	updates := exp.Summary().Updates()
+	if len(updates) != 1 || updates[0] != 42.0 {
+		t.Fatalf("expected [42.0], got %v", updates)
 	}
 }

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -197,3 +197,47 @@ func TestMockMeter_Unregister_Unexpected(t *testing.T) {
 		t.Fatal("expected unexpected call to be recorded")
 	}
 }
+
+func TestMockMeter_ExpectationsWereMet_OK(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	m.ExpectCounter("hits")
+
+	_ = m.Init()
+	_ = m.Counter("hits")
+
+	if err := m.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_ExpectationsWereMet_Unfulfilled(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	// Never call Init — expectation remains unfulfilled.
+
+	if err := m.ExpectationsWereMet(); err == nil {
+		t.Fatal("expected error for unfulfilled expectation")
+	}
+}
+
+func TestMockMeter_ExpectationsWereMet_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	_ = m.Counter("unregistered") // no expectation
+
+	if err := m.ExpectationsWereMet(); err == nil {
+		t.Fatal("expected error for unexpected call")
+	}
+}
+
+func TestMockMeter_CloneSet(t *testing.T) {
+	m := NewMockMeter(meter.Name("base"))
+	c := m.Clone()
+	if c == nil {
+		t.Fatal("Clone returned nil")
+	}
+	s := m.Set()
+	if s == nil {
+		t.Fatal("Set returned nil")
+	}
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -34,3 +34,57 @@ func TestMockMeter_Init_Unexpected(t *testing.T) {
 		t.Fatal("expected error for unexpected Init call")
 	}
 }
+
+func TestMockMeter_Counter(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectCounter("requests", "method", "GET")
+
+	c := m.Counter("requests", "method", "GET")
+	c.Inc()
+	c.Inc()
+	c.Add(3)
+	c.Dec()
+	c.Set(10)
+
+	if got := exp.Counter().Get(); got != 10 {
+		t.Fatalf("expected 10, got %d", got)
+	}
+}
+
+func TestMockMeter_Counter_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	_ = m.Counter("hits") // no expectation — goes to unexpected
+	if len(m.unexpected) == 0 {
+		t.Fatal("expected unexpected call to be recorded")
+	}
+}
+
+func TestMockMeter_FloatCounter(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectFloatCounter("bytes")
+
+	fc := m.FloatCounter("bytes")
+	fc.Add(1.5)
+	fc.Add(2.5)
+	fc.Sub(1.0)
+	fc.Set(5.0)
+
+	if got := exp.FloatCounter().Get(); got != 5.0 {
+		t.Fatalf("expected 5.0, got %f", got)
+	}
+}
+
+func TestMockMeter_Gauge(t *testing.T) {
+	m := NewMockMeter()
+	exp := m.ExpectGauge("temperature")
+
+	g := m.Gauge("temperature", nil)
+	g.Set(42.0)
+	g.Inc()
+	g.Dec()
+	g.Add(0.5)
+
+	if got := exp.Gauge().Get(); got != 42.5 {
+		t.Fatalf("expected 42.5, got %f", got)
+	}
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -1,0 +1,11 @@
+package mock
+
+import (
+	"testing"
+
+	"go.unistack.org/micro/v5/meter"
+)
+
+func TestMockMeter_Implements(t *testing.T) {
+	var _ meter.Meter = NewMockMeter()
+}

--- a/meter/mock/mock_test.go
+++ b/meter/mock/mock_test.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"errors"
 	"testing"
 
 	"go.unistack.org/micro/v5/meter"
@@ -8,4 +9,28 @@ import (
 
 func TestMockMeter_Implements(t *testing.T) {
 	var _ meter.Meter = NewMockMeter()
+}
+
+func TestMockMeter_Init_Success(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit()
+	if err := m.Init(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMockMeter_Init_Error(t *testing.T) {
+	m := NewMockMeter()
+	m.ExpectInit().WillReturnError(errors.New("init failed"))
+	err := m.Init()
+	if err == nil || err.Error() != "init failed" {
+		t.Fatalf("expected 'init failed', got %v", err)
+	}
+}
+
+func TestMockMeter_Init_Unexpected(t *testing.T) {
+	m := NewMockMeter()
+	if err := m.Init(); err == nil {
+		t.Fatal("expected error for unexpected Init call")
+	}
 }


### PR DESCRIPTION
## Summary

- Add `go.unistack.org/micro/v5/meter/mock` package implementing `meter.Meter` with strict expectation-based testing (modelled after `broker/mock`)
- `MockMeter` holds an ordered slice of expectations registered via `ExpectXxx()` methods; each method call matches the first untriggered expectation by name, marks it triggered, and returns configured values
- Sub-interface mocks (`mockCounter`, `mockFloatCounter`, `mockGauge`, `mockHistogram`, `mockSummary`) accumulate real values so tests can inspect them via `exp.Counter().Get()`, `exp.Histogram().Updates()`, etc.
- `ExpectationsWereMet()` reports both unfulfilled expectations and unexpected calls

## What's included

| Type | Purpose |
|------|---------|
| `ExpectedInit` | `Init()` with `WillReturnError` |
| `ExpectedWrite` | `Write()` with `WillReturnError` |
| `ExpectedUnregister` | `Unregister()` with `WillReturn(bool)` |
| `ExpectedCounter` | `Counter()` — exposes `*mockCounter` for value inspection |
| `ExpectedFloatCounter` | `FloatCounter()` — exposes `*mockFloatCounter` |
| `ExpectedGauge` | `Gauge()` — exposes `*mockGauge` |
| `ExpectedHistogram` | `Histogram()` — exposes `*mockHistogram` |
| `ExpectedHistogramExt` | `HistogramExt()` — exposes `*mockHistogram` |
| `ExpectedSummary` | `Summary()` — exposes `*mockSummary` |
| `ExpectedSummaryExt` | `SummaryExt()` — exposes `*mockSummary` |

## Test Plan

- [ ] `go test go.unistack.org/micro/v5/meter/mock -v -count=1` — 22 tests, all PASS
- [ ] Verify unexpected calls are recorded and reported by `ExpectationsWereMet()`
- [ ] Verify unfulfilled expectations are reported by `ExpectationsWereMet()`
- [ ] Verify `Clone()` and `Set()` work without registering expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)